### PR TITLE
Fix shear norm, PSF flux normalization, vmap log_prob

### DIFF
--- a/kl_pipe/psf.py
+++ b/kl_pipe/psf.py
@@ -346,6 +346,11 @@ def convolve_flux_weighted(
     jnp.ndarray
         Flux-weighted, PSF-convolved velocity map, shape == psf_data.coarse_shape.
     """
+    # normalize intensity to prevent FFT overflow with large flux values
+    # (e.g. TNG luminosities); cancels exactly in the ratio Conv(I*v)/Conv(I)
+    i_max = jnp.max(jnp.abs(intensity))
+    intensity = intensity / jnp.maximum(i_max, 1.0)
+
     conv_iv = _convolve_fft_raw(intensity * velocity, psf_data)
     conv_i = _convolve_fft_raw(intensity, psf_data)
 
@@ -427,6 +432,10 @@ def convolve_flux_weighted_numpy(
     np.ndarray
         Flux-weighted, PSF-convolved velocity map.
     """
+    # normalize intensity to prevent FFT overflow with large flux values
+    i_max = np.max(np.abs(intensity))
+    intensity = intensity / max(i_max, 1.0)
+
     conv_iv = convolve_fft_numpy(intensity * velocity, kernel, padded_shape)
     conv_i = convolve_fft_numpy(intensity, kernel, padded_shape)
 

--- a/kl_pipe/sampling/blackjax.py
+++ b/kl_pipe/sampling/blackjax.py
@@ -189,8 +189,9 @@ class BlackJAXSampler(Sampler):
         # Convert to numpy
         samples_np = np.array(samples)
 
-        # Compute log_prob for final samples
-        log_prob_vals = np.array([float(log_prob_fn(s)) for s in samples_np])
+        # Compute log_prob for final samples (batched via vmap)
+        _batched_log_prob = jax.jit(jax.vmap(self.task._log_posterior_jittable))
+        log_prob_vals = np.asarray(_batched_log_prob(jnp.array(samples_np)))
 
         elapsed = time.time() - start_time
 

--- a/kl_pipe/sampling/numpyro.py
+++ b/kl_pipe/sampling/numpyro.py
@@ -557,11 +557,9 @@ class NumpyroSampler(Sampler):
 
         samples = np.column_stack(samples_list)
 
-        # Compute log probabilities for samples
-        log_posterior_fn = self.task.get_log_posterior_fn()
-        log_probs = np.array(
-            [float(log_posterior_fn(jnp.array(theta))) for theta in samples]
-        )
+        # Compute log probabilities for samples (batched via vmap)
+        _batched_log_posterior = jax.jit(jax.vmap(self.task._log_posterior_jittable))
+        log_probs = np.asarray(_batched_log_posterior(jnp.array(samples)))
 
         # Collect diagnostics
         diagnostics = self._collect_diagnostics(mcmc, self._reparam_scales)

--- a/kl_pipe/tng/data_vectors.py
+++ b/kl_pipe/tng/data_vectors.py
@@ -671,7 +671,7 @@ class TNGDataVectorGenerator:
         # ===================================================================
         if g1 != 0 or g2 != 0:
             # source→cen = A^{-1} = norm * [[1+g1, g2], [g2, 1-g1]]
-            norm = 1.0 / (1.0 - (g1**2 + g2**2))
+            norm = 1.0 / np.sqrt(1.0 - (g1**2 + g2**2))
             x_cen = norm * ((1.0 + g1) * x_source + g2 * y_source)
             y_cen = norm * (g2 * x_source + (1.0 - g1) * y_source)
         else:


### PR DESCRIPTION
## Summary
Addresses 3 review comments from @pranjalrs on PR #20:

- **`kl_pipe/tng/data_vectors.py`**: add missing `np.sqrt` in shear transform norm — all other implementations use `1/√(1-|g|²)`, this one was `1/(1-|g|²)`
- **`kl_pipe/psf.py`**: normalize intensity by max before FFTs in both JAX and numpy `convolve_flux_weighted` — prevents overflow/precision loss with large TNG flux values
- **`kl_pipe/sampling/numpyro.py` + `blackjax.py`**: replace sequential list comprehension with `jax.vmap` for batched log posterior evaluation

**NOTE:** This hot fix is needed as we accidentally merged #20 before incorporating this feedback into `se/psf`