### PR TITLE
Dust attenuation modelling for arbitary orienation of galaxies

### DIFF
--- a/data/cyverse/cyverse_data.conf
+++ b/data/cyverse/cyverse_data.conf
@@ -24,6 +24,19 @@ https://data.cyverse.org/dav-anon/iplant/home/severett/test/success.txt | cyvers
 
 # TNG50 Mock Data Files
 # These are in ylai1998's space but shared with the team
-https://data.cyverse.org/dav/iplant/home/ylai1998/KL_lensing_TNG/Mocks/gas_data_analysis.npz | tng50/gas_data_analysis.npz
-https://data.cyverse.org/dav/iplant/home/ylai1998/KL_lensing_TNG/Mocks/stellar_data_analysis.npz | tng50/stellar_data_analysis.npz
-https://data.cyverse.org/dav/iplant/home/ylai1998/KL_lensing_TNG/Mocks/subhalo_data_analysis.npz | tng50/subhalo_data_analysis.npz
+# https://data.cyverse.org/dav/iplant/home/ylai1998/KL_lensing_TNG/Mocks/gas_data_analysis.npz | tng50/gas_data_analysis.npz
+# https://data.cyverse.org/dav/iplant/home/ylai1998/KL_lensing_TNG/Mocks/stellar_data_analysis.npz | tng50/stellar_data_analysis.npz
+# https://data.cyverse.org/dav/iplant/home/ylai1998/KL_lensing_TNG/Mocks/subhalo_data_analysis.npz | tng50/subhalo_data_analysis.npz
+https://data.cyverse.org/dav/iplant/home/ylai1998/TNG50_mocks/gas_data_analysis_gold.npz | tng50/gas_data_analysis.npz
+https://data.cyverse.org/dav/iplant/home/ylai1998/TNG50_mocks/stellar_data_analysis_gold.npz | tng50/stellar_data_analysis.npz
+https://data.cyverse.org/dav/iplant/home/ylai1998/TNG50_mocks/subhalo_data_analysis_gold.npz | tng50/subhalo_data_analysis.npz
+
+# High resolution SDSS stellar photometric data for BC03 SED modeling
+https://data.cyverse.org/dav/iplant/home/ylai1998/TNG50_mocks/SDSS_hr_stelib_stellar_photometrics.hdf5 | tng50/SDSS_hr_stelib_stellar_photometrics.hdf5
+
+#Filters for SDSS r, u, g, i, z bands
+https://data.cyverse.org/dav/iplant/home/ylai1998/TNG50_mocks/g_SDSS.res | tng50/g_SDSS.res
+https://data.cyverse.org/dav/iplant/home/ylai1998/TNG50_mocks/r_SDSS.res | tng50/r_SDSS.res
+https://data.cyverse.org/dav/iplant/home/ylai1998/TNG50_mocks/i_SDSS.res | tng50/i_SDSS.res
+https://data.cyverse.org/dav/iplant/home/ylai1998/TNG50_mocks/u_SDSS.res | tng50/u_SDSS.res
+https://data.cyverse.org/dav/iplant/home/ylai1998/TNG50_mocks/z_SDSS.res | tng50/z_SDSS.res

--- a/kl_pipe/tng/README.md
+++ b/kl_pipe/tng/README.md
@@ -84,11 +84,11 @@ velocity, variance = gen.generate_velocity_map(config, snr=50, seed=42)
 ## Coordinate Systems
 
 ### TNG Native Frame
-- **Units**: Comoving kpc/h (must convert to physical)
+- **Units**: Comoving kpc (physical distance)
 - **Origin**: Subhalo position
 - **Inclination**: 0-180° (0°=face-on from above, 90°=edge-on, 180°=face-on from below)
 - **Position Angle**: 0-360° (East of North convention)
-- **Redshift**: z~0.011 (Distance ~50 Mpc)
+- **Redshift**: z~0.0 (Snapshot 99)
 - **Angular Size**: ~21 arcmin (~1300 arcsec) - **too large for sub-arcsec observations!**
 
 ### Observer Frame
@@ -143,6 +143,12 @@ Run `experiments/sweverett/tng/offset_exploration.ipynb` to visualize 3D structu
 - Vertical velocities (v_z) are negated to preserve physics
 
 This maintains full 0-180° parameter space coverage while avoiding coordinate explosion when cos(i) < 0.
+
+## Dust Attenuation scheme
+- Applying TNG's dust attenuation to stellar luminosities (if `use_dusted=True`) results in more realistic intensity maps, especially in edge-on views where dust lanes are prominent.
+- Dust attenuation is band-dependent and can significantly reduce flux in edge-on orientations, creating characteristic dust lanes and asymmetries in the intensity maps.
+- For testing or idealized cases, `use_dusted=False` can be used to render dust-free luminosities, which may be desirable for certain analyses or visualizations.
+- See more detail of the dust attenuation scheme in section 2.1 of https://arxiv.org/abs/1610.07605. 
 
 ## Gridding Algorithms
 

--- a/kl_pipe/tng/data_vectors.py
+++ b/kl_pipe/tng/data_vectors.py
@@ -95,6 +95,11 @@ import numpy as np
 from dataclasses import dataclass
 from astropy.cosmology import FlatLambdaCDM
 from astropy import units as u
+from numba import njit, prange
+from scipy.integrate import simpson
+import h5py
+from scipy.interpolate import interp1d
+from pathlib import Path
 
 from ..parameters import ImagePars
 from ..utils import build_map_grid_from_image_pars
@@ -107,15 +112,18 @@ TNG_COSMOLOGY = FlatLambdaCDM(
 )
 
 # TNG50 snapshot 99 redshift (all galaxies in our dataset)
-TNG50_SNAPSHOT_99_REDSHIFT = 0.0108
+# TNG50_SNAPSHOT_99_REDSHIFT = 0.0108
+TNG50_SNAPSHOT_99_REDSHIFT = 0.0
+
+# Default data directory. This is needed to load the auxillary data files for the BC03 models, which are used for converting between
+# luminosity and magnitude, and for distance conversions. The BC03 models are stored in a preprocessed HDF5 file that contains the
+# SED and absolute magnitude grids for different bands, as well as the age and metallicity grids.
+DEFAULT_DATA_DIR = Path(__file__).parent.parent.parent / "data" / "tng50"
 
 
 def convert_tng_to_arcsec(
     coords_kpc: np.ndarray,
-    distance_mpc: float,
-    h: float = 0.6774,
     target_redshift: Optional[float] = None,
-    native_redshift: float = TNG50_SNAPSHOT_99_REDSHIFT,
 ) -> np.ndarray:
     """
     Convert TNG comoving coordinates to angular separation in arcsec.
@@ -124,17 +132,13 @@ def convert_tng_to_arcsec(
     then to arcsec using the angular diameter distance.
 
     Optionally rescale to a different redshift for realistic sub-arcsec observations.
-    TNG50 galaxies are at z~0.01 (~50 Mpc), appearing ~21 arcmin on sky.
-    Use target_redshift to place at higher z for Roman-like observations.
+    For TNG galaxies at snapshot 99, they are evolved to redshift zero. We need to
+    use target_redshift to place them at higher redshift for Roman-like observations.
 
     Parameters
     ----------
     coords_kpc : np.ndarray
         Coordinates in comoving kpc/h (TNG native units)
-    distance_mpc : float
-        Angular diameter distance in Mpc (from subhalo data)
-    h : float, default=0.6774
-        Hubble parameter h for TNG50
     target_redshift : float, optional
         If provided, scale angular size to this redshift.
         Good values: 0.5-1.0 for Roman-like sub-arcsec resolution.
@@ -147,32 +151,317 @@ def convert_tng_to_arcsec(
     coords_arcsec : np.ndarray
         Angular coordinates in arcsec
     """
-    # Step 1: Convert comoving to physical coordinates
-    # TNG stores coordinates in comoving kpc/h, need to convert to physical kpc
-    # Physical distance = (comoving distance / h) * a, where a = 1/(1+z) is scale factor
-    coords_comoving_kpc = coords_kpc / h  # Remove h factor
-    scale_factor_a = 1.0 / (1.0 + native_redshift)  # Scale factor a = 1/(1+z)
-    coords_physical_kpc = coords_comoving_kpc * scale_factor_a
+    # Step 1: Load in the physical coordinates in kpc.
+    coords_physical_kpc = coords_kpc
+    # The output catalogue already has physical coordinates in kpc, so we skip the comoving to physical conversion step. The distance_mpc is also the physical distance,
+    # so it is consistent with the physical coordinates.
 
     # Step 2: Convert physical kpc to angular separation at native redshift
     # theta = d_phys / D_A, where D_A is angular diameter distance
     arcsec_per_radian = 180.0 * 3600.0 / np.pi  # 180 deg/rad * 3600 arcsec/deg / pi
-    kpc_per_mpc = 1000.0
-    d_a_native_mpc = distance_mpc  # Angular diameter distance at native redshift
-    scale_factor = arcsec_per_radian / (d_a_native_mpc * kpc_per_mpc)  # arcsec per kpc
-    coords_arcsec = coords_physical_kpc * scale_factor
 
     # Step 3: Optionally rescale to target redshift using proper cosmology
-    if target_redshift is not None and target_redshift != native_redshift:
+    if target_redshift is not None:
         # Use astropy cosmology for accurate angular diameter distance scaling
         # Angular size scales as theta ∝ d_phys / D_A(z)
-        d_a_native = TNG_COSMOLOGY.angular_diameter_distance(native_redshift)
-        d_a_target = TNG_COSMOLOGY.angular_diameter_distance(target_redshift)
-        # Larger D_A → smaller angular size (more distant)
-        scale_ratio = (d_a_native / d_a_target).value  # ratio of D_A values
-        coords_arcsec *= scale_ratio
+
+        # Convert angular diameter distance to target redshift in kpc since the galaxy size is in kpc.
+        d_a_target = TNG_COSMOLOGY.angular_diameter_distance(target_redshift).to_value(
+            u.kpc
+        )
+
+        # TNG galaxies at snapshot 99 are at redshift zero, we know the intrinsic size of the galaxy in kpc, so just need to divide it by the distance to the galaxy to
+        # calculate the angular size in radians, then convert to arcseconds.
+
+        coords_arcsec = coords_physical_kpc * arcsec_per_radian / d_a_target
+
+    else:
+        raise ValueError(
+            "Target redshift must be provided and different from native redshift for angular size scaling if using the TNG50 sample at snapshot 99."
+        )
 
     return coords_arcsec
+
+
+# -------------------------------------------------------------------------
+# 1. THE 3D SED KERNEL. Using numba to unroll the for loops and do the interpolation purely in the CPU cache for maximum speed.
+# -------------------------------------------------------------------------
+@njit(parallel=True, fastmath=True)
+def numba_bilinear_3d(
+    met_chunk: np.ndarray,
+    age_chunk: np.ndarray,
+    met_grid: np.ndarray,
+    age_grid: np.ndarray,
+    band_grid: np.ndarray,
+) -> np.ndarray:
+    """Bilinear interpolation in 2D (metallicity, age) for each particle to get SED for a specific band. Returns array of shape (N_particles, N_wave) with interpolated SEDs.
+
+    The input metallicity is the mass metallicity ratio from the TNG simulation. Not solar metallicity. The input age is in Gyr.
+    Parameters
+    ----------
+    met_chunk : np.ndarray
+        Metallicity values for each particle
+    age_chunk : np.ndarray
+        Age values for each particle
+    met_grid : np.ndarray
+        Grid of metallicity values
+    age_grid : np.ndarray
+        Grid of age values
+    band_grid : np.ndarray
+        Grid of SED values for a specific band, shape (N_met, N_age, N_wave)
+
+    Returns
+    -------
+    np.ndarray
+        Interpolated SEDs for each particle
+    """
+
+    N_particles = len(met_chunk)
+    N_wave = band_grid.shape[2]
+
+    # Pre-allocate the ONLY array that gets written to RAM
+    out_seds = np.empty((N_particles, N_wave), dtype=band_grid.dtype)
+
+    # prange splits the 100,000 particles across your CPU cores!
+    for i in prange(N_particles):
+        met = met_chunk[i]
+        age = age_chunk[i]
+
+        # Numba perfectly supports np.searchsorted
+        idx_met = np.searchsorted(met_grid, met) - 1
+        idx_age = np.searchsorted(age_grid, age) - 1
+
+        # Numba doesn't like np.clip on scalars, so we write explicit bounds
+        if idx_met < 0:
+            idx_met = 0
+        if idx_met > len(met_grid) - 2:
+            idx_met = len(met_grid) - 2
+        if idx_age < 0:
+            idx_age = 0
+        if idx_age > len(age_grid) - 2:
+            idx_age = len(age_grid) - 2
+
+        met1 = met_grid[idx_met]
+        met2 = met_grid[idx_met + 1]
+        age1 = age_grid[idx_age]
+        age2 = age_grid[idx_age + 1]
+
+        tx = (met - met1) / (met2 - met1)
+        ty = (age - age1) / (age2 - age1)
+
+        if tx < 0.0:
+            tx = 0.0
+        if tx > 1.0:
+            tx = 1.0
+        if ty < 0.0:
+            ty = 0.0
+        if ty > 1.0:
+            ty = 1.0
+
+        # Weights for the four corners of the grid cell
+        w11 = (1.0 - tx) * (1.0 - ty)
+        w21 = tx * (1.0 - ty)
+        w12 = (1.0 - tx) * ty
+        w22 = tx * ty
+
+        # THE MAGIC: Loop over wavelengths purely inside the CPU cache!
+        for j in range(N_wave):
+            out_seds[i, j] = (
+                band_grid[idx_met, idx_age, j] * w11
+                + band_grid[idx_met + 1, idx_age, j] * w21
+                + band_grid[idx_met, idx_age + 1, j] * w12
+                + band_grid[idx_met + 1, idx_age + 1, j] * w22
+            )
+
+    return out_seds
+
+
+# -------------------------------------------------------------------------
+# 2. THE 2D ABSOLUTE MAGNITUDE KERNEL. Similar to the 3D SED kernel but simpler since the grid is only 2D (metallicity, age) and the output is a single magnitude value
+# for each particle instead of a full SED. Still uses numba for speed.
+# -------------------------------------------------------------------------
+@njit(parallel=True, fastmath=True)
+def numba_bilinear_2d(
+    met_chunk: np.ndarray,
+    age_chunk: np.ndarray,
+    met_grid: np.ndarray,
+    age_grid: np.ndarray,
+    band_grid: np.ndarray,
+) -> np.ndarray:
+    """Bilinear interpolation in 2D (metallicity, age) for each particle to get absolute magnitude for a specific band. Returns array of shape (N_particles,)
+    with interpolated magnitudes.
+
+    The input metallicity is the mass metallicity ratio from the TNG simulation. Not solar metallicity. The input age is in Gyr.
+    Parameters
+    ----------
+    met_chunk : np.ndarray
+        Metallicity values for each particle
+    age_chunk : np.ndarray
+        Age values for each particle
+    met_grid : np.ndarray
+        Grid of metallicity values
+    age_grid : np.ndarray
+        Grid of age values
+    band_grid : np.ndarray
+        Grid of absolute magnitudes for a specific band, shape (N_met, N_age)
+
+    Returns
+    -------
+    np.ndarray
+        Interpolated magnitudes for each particle
+    """
+    N_particles = len(met_chunk)
+    out_mags = np.empty(N_particles, dtype=band_grid.dtype)
+
+    for i in prange(N_particles):
+        met = met_chunk[i]
+        age = age_chunk[i]
+
+        idx_met = np.searchsorted(met_grid, met) - 1
+        idx_age = np.searchsorted(age_grid, age) - 1
+
+        if idx_met < 0:
+            idx_met = 0
+        if idx_met > len(met_grid) - 2:
+            idx_met = len(met_grid) - 2
+        if idx_age < 0:
+            idx_age = 0
+        if idx_age > len(age_grid) - 2:
+            idx_age = len(age_grid) - 2
+
+        met1 = met_grid[idx_met]
+        met2 = met_grid[idx_met + 1]
+        age1 = age_grid[idx_age]
+        age2 = age_grid[idx_age + 1]
+
+        tx = (met - met1) / (met2 - met1)
+        ty = (age - age1) / (age2 - age1)
+
+        if tx < 0.0:
+            tx = 0.0
+        if tx > 1.0:
+            tx = 1.0
+        if ty < 0.0:
+            ty = 0.0
+        if ty > 1.0:
+            ty = 1.0
+
+        w11 = (1.0 - tx) * (1.0 - ty)
+        w21 = tx * (1.0 - ty)
+        w12 = (1.0 - tx) * ty
+        w22 = tx * ty
+
+        out_mags[i] = (
+            band_grid[idx_met, idx_age] * w11
+            + band_grid[idx_met + 1, idx_age] * w21
+            + band_grid[idx_met, idx_age + 1] * w12
+            + band_grid[idx_met + 1, idx_age + 1] * w22
+        )
+
+    return out_mags
+
+
+@njit(fastmath=True)
+def sph_project_2d(
+    x: np.ndarray,
+    y: np.ndarray,
+    h_tng: np.ndarray,
+    weights: np.ndarray,
+    x_edges: np.ndarray,
+    y_edges: np.ndarray,
+) -> np.ndarray:
+    """
+    2D SPH projection using cubic spline kernel. This is the core of the gridding process, where we take particle positions, smoothing lengths, and weights
+    (e.g., luminosities or masses) and project them onto a 2D pixel grid defined by x_edges and y_edges. Using numba to speed up the nested loops and avoid temporary arrays
+    for maximum performance.
+
+    Parameters:
+    x : np.ndarray
+        X coordinates of particles in kpc
+    y : np.ndarray
+        Y coordinates of particles in kpc
+    h_tng : np.ndarray
+        Smoothing lengths of particles in kpc (TNG defines Hsml as the full support radius, so we divide by 2 in the code to get the "h" used in the kernel)
+    weights : np.ndarray
+        Weights of particles (e.g., luminosities or masses)
+    x_edges : np.ndarray
+        Edges of the pixel grid in the X direction
+    y_edges : np.ndarray
+        Edges of the pixel grid in the Y direction
+
+    Returns
+    -------
+    np.ndarray
+        2D grid with projected values
+
+    """
+
+    nx = len(x_edges) - 1
+    ny = len(y_edges) - 1
+    grid = np.zeros((nx, ny))
+
+    dx = x_edges[1] - x_edges[0]
+    dy = y_edges[1] - y_edges[0]
+
+    x_centers = 0.5 * (x_edges[:-1] + x_edges[1:])
+    y_centers = 0.5 * (y_edges[:-1] + y_edges[1:])
+
+    for i in range(len(x)):
+        xi, yi = x[i], y[i]
+        # TNG defines Hsml as the full support radius. Our math expects half of that.
+        hi = h_tng[i] / 2.0
+        wi = weights[i]
+
+        if hi <= 0:
+            continue
+
+        # Handle Undersampling: If the particle is smaller than a pixel, dump it as a point mass
+        if hi < 0.5 * min(dx, dy):
+            ix = np.searchsorted(x_edges, xi) - 1
+            iy = np.searchsorted(y_edges, yi) - 1
+
+            if 0 <= ix < nx and 0 <= iy < ny:
+                # Convert mass to surface density
+                grid[ix, iy] += wi / (dx * dy)
+            continue
+
+        # Determine affected pixel range
+        x_min = xi - 2 * hi
+        x_max = xi + 2 * hi
+        y_min = yi - 2 * hi
+        y_max = yi + 2 * hi
+
+        ix_min = np.searchsorted(x_centers, x_min, side="left")
+        ix_max = np.searchsorted(x_centers, x_max, side="right")
+        iy_min = np.searchsorted(y_centers, y_min, side="left")
+        iy_max = np.searchsorted(y_centers, y_max, side="right")
+
+        ix_min = max(ix_min, 0)
+        ix_max = min(ix_max, nx)
+        iy_min = max(iy_min, 0)
+        iy_max = min(iy_max, ny)
+
+        # The 2D cubic spline normalization factor
+        norm = 10.0 / (7.0 * np.pi * hi**2)
+
+        # Pure scalar nested loops (Zero temporary arrays!)
+        for ix in range(ix_min, ix_max):
+            dx_pos = x_centers[ix] - xi
+
+            for iy in range(iy_min, iy_max):
+                dy_pos = y_centers[iy] - yi
+
+                r = np.sqrt(dx_pos**2 + dy_pos**2)
+                q = r / hi
+
+                if q < 1.0:
+                    w_val = norm * (1.0 - 1.5 * q**2 + 0.75 * q**3)
+                    grid[ix, iy] += wi * w_val
+                elif q < 2.0:
+                    w_val = norm * (0.25 * (2.0 - q) ** 3)
+                    grid[ix, iy] += wi * w_val
+
+    return grid
 
 
 @dataclass
@@ -220,7 +509,7 @@ class TNGRenderConfig:
     """
 
     image_pars: ImagePars
-    band: str = 'r'
+    band: str = "r"
     use_dusted: bool = True
     center_on_peak: bool = True
     use_native_orientation: bool = True
@@ -235,8 +524,8 @@ class TNGRenderConfig:
         """Validate configuration parameters."""
         # Validate shear parameters if custom orientation is used
         if not self.use_native_orientation and self.pars is not None:
-            g1 = self.pars.get('g1', 0.0)
-            g2 = self.pars.get('g2', 0.0)
+            g1 = self.pars.get("g1", 0.0)
+            g2 = self.pars.get("g2", 0.0)
             gamma = np.sqrt(g1**2 + g2**2)
             weak_lensing_limit = 1.0
             if gamma >= weak_lensing_limit:
@@ -259,7 +548,7 @@ class TNGDataVectorGenerator:
     2. Transform to new orientation (use_native_orientation=False, provide pars)
     """
 
-    def __init__(self, galaxy_data: Dict[str, Dict]):
+    def __init__(self, galaxy_data: Dict[str, Dict], data_dir: Optional[Path] = None):
         """
         Initialize generator for a specific galaxy.
 
@@ -270,9 +559,27 @@ class TNGDataVectorGenerator:
             the TNG data for one galaxy (from TNG50MockData.get_galaxy())
         """
         self.galaxy_data = galaxy_data
-        self.stellar = galaxy_data.get('stellar')
-        self.gas = galaxy_data.get('gas')
-        self.subhalo = galaxy_data.get('subhalo')
+        self.stellar = galaxy_data.get("stellar")
+        self.gas = galaxy_data.get("gas")
+        self.subhalo = galaxy_data.get("subhalo")
+
+        # Setting some constant parameters for the BC03 models. These are used for converting between luminosity and magnitude, and for distance conversions.
+        self.L_sun = 3.826e33  # erg/s. The default value in galaxev
+        self.csol = 2.99792458e10  # speed of light in cm/s
+        self.H_mass = 1.6735575e-24  # g
+        self.Msun_to_g = 1.98847e33  # solar mass in grams
+        self.kpc_to_cm = 3.085677581491367e21  # kpc to cm
+        self.chunk_size = 100000  # Number of particles to process in each chunk for interpolation. Reduce if you have memory issues, increase if you want faster processing (but more memory usage).
+        self.Mpc = 3.085677581491367e24  # cm in a Mpc, used for distance conversions
+
+        # AB absolute manitudes in different SDSS bands
+        self.M_abs_sun = {
+            "u": 6.39,
+            "g": 5.11,
+            "r": 4.65,
+            "i": 4.53,
+            "z": 4.50,
+        }
 
         if self.stellar is None:
             raise ValueError("Stellar data required for data vector generation")
@@ -282,15 +589,21 @@ class TNGDataVectorGenerator:
                 "Subhalo data required for coordinate conversion and orientation"
             )
 
+        if data_dir is None:
+            data_dir = DEFAULT_DATA_DIR
+        output_path = data_dir / "SDSS_hr_stelib_stellar_photometrics.hdf5"
+        filtdir = data_dir
+        self.load_BC03_models(output_path, filtdir)
+
         # Store key properties
-        self.distance_mpc = float(self.subhalo['DistanceMpc'])
+        self.distance_mpc = float(self.subhalo["DistanceMpc"])
         self.native_redshift = TNG50_SNAPSHOT_99_REDSHIFT  # Snapshot 99
-        self.native_inclination_deg = float(self.subhalo['Inclination_star'])
-        self.native_pa_deg = float(self.subhalo['Position_Angle_star'])
+        self.native_inclination_deg = float(self.subhalo["Inclination_star"])
+        self.native_pa_deg = float(self.subhalo["Position_Angle_star"])
 
         # Store gas orientation for offset preservation
-        self.native_gas_inclination_deg = float(self.subhalo['Inclination_gas'])
-        self.native_gas_pa_deg = float(self.subhalo['Position_Angle_gas'])
+        self.native_gas_inclination_deg = float(self.subhalo["Inclination_gas"])
+        self.native_gas_pa_deg = float(self.subhalo["Position_Angle_gas"])
 
         # Compute 3D rotation matrices to transform from TNG simulation frame
         # to face-on disk frame. We compute SEPARATE matrices for stellar and gas
@@ -313,6 +626,788 @@ class TNGDataVectorGenerator:
         self.native_cosi = np.cos(np.radians(self.native_inclination_deg))
         self.native_pa_rad = np.radians(self.native_pa_deg)
 
+    def load_BC03_models(
+        self, output_path: Path, filtdir: Path, bands: set = {"g", "r", "i", "u", "z"}
+    ):
+        """Load BC03 SED and absolute magnitude grids from preprocessed HDF5 file. They are both interpolated in the same way (bilinear
+        in log(age) and metallicity) to get the SED and absolute magnitude for each particle based on its age and metallicity. The SED grid
+        has shape (N_metallicity, N_age, N_wave) and the absolute magnitude grid has shape (N_metallicity, N_age) for each band. The grids
+        are stored as attributes of the class for later use in interpolation. Currently only supports SDSS g, r, i, u, z bands, but can be
+        extended to other filters by adding more datasets to the HDF5 file and loading them here.
+
+        Parameters
+        ----------
+        output_path : Path
+            Path to the preprocessed HDF5 file containing BC03 models.
+        filtname : Path
+            Path to the filter file.
+        bands : set, optional
+            Set of bands to load, by default {"g", "r", "i", "u", "z"}.
+        """
+
+        self.absolute_mag_grid = {}
+        with h5py.File(output_path, "r") as f:
+            self.BC03_age_grid_logGr = f["LogAgeInGyr_bins"][:]  # log(age in Gyr) grid
+            self.BC03_metallicity_grid = f["Metallicity_bins"][:]
+            BC03_wave_ang = f["Wavelengths"][:]
+            BC03_SED_grid = f["SEDs"][:].astype(
+                np.float64
+            )  # shape (N_metallicity, N_age, N_wave)
+            self.BC03_N_age = f["N_LogAgeInGyr"][()]
+            self.BC03_N_metallicity = f["N_Metallicity"][()]
+
+            for band in bands:
+                # Absolute magnitude grid for this band has shape (N_metallicity, N_age)
+                self.absolute_mag_grid[band] = f["Magnitude_" + band][:]
+
+        self.wavelength_SED_within_filter = {}
+        self.SED_within_filter_grid = {}
+        self.numerator_weights = {}
+        self.denominator_scalar = {}
+        for band in bands:
+            # Currently limited to the SDSS filters, but could be extended in the future.
+            filtname = filtdir / f"{band}_SDSS.res"
+            f = open(filtname, "r")
+            filt_wave, filt_t = np.loadtxt(f, unpack=True)
+            f.close()
+
+            filt_spline = interp1d(
+                filt_wave, filt_t, kind="linear", bounds_error=False, fill_value=0.0
+            )
+
+            wmin_filt, wmax_filt = filt_wave[0], filt_wave[-1]
+
+            cond_filt_rest = (BC03_wave_ang >= wmin_filt) & (BC03_wave_ang <= wmax_filt)
+
+            response_rest = filt_spline(BC03_wave_ang[cond_filt_rest])
+            nu_filter_rest = (
+                self.csol * 1e8 / BC03_wave_ang[cond_filt_rest]
+            )  # Convert from angstrom to cm for the frequency calculation
+
+            response_rest = np.flipud(response_rest)
+            nu_filter_rest = np.flipud(nu_filter_rest)
+
+            self.wavelength_SED_within_filter[band] = BC03_wave_ang[
+                cond_filt_rest
+            ]  # Wavelengths in angstroms
+
+            luminosity_density_erg = (
+                BC03_SED_grid[:, :, cond_filt_rest] * self.L_sun * 1e8
+            )  # Convert from L_sun/angstrom to erg/s/angstrom using the solar luminosity in erg/s and the conversion from angstrom to cm
+            luminosity_density_nu = (
+                luminosity_density_erg
+                * (self.wavelength_SED_within_filter[band] * 1e-8) ** 2
+                / self.csol
+            )[
+                ..., ::-1
+            ]  # erg/s/Hz and swap the last axis to be in increasing frequency order
+
+            self.SED_within_filter_grid[band] = luminosity_density_nu
+
+            # 1. Trick SciPy into calculating the exact integration weights ONCE for the whole frequency range which is fixed.
+            simpson_w = simpson(np.eye(len(nu_filter_rest)), x=nu_filter_rest, axis=-1)
+
+            self.numerator_weights[band] = (response_rest / nu_filter_rest) * simpson_w
+
+            self.denominator_scalar[band] = simpson(
+                response_rest / nu_filter_rest, x=nu_filter_rest
+            )
+
+        # Using galaxev models to estimate the absolute magnitude from stellar mass and age
+
+    def _estimate_magnitude_luminosity(
+        self,
+        coords_2d_stellar_rotate: np.ndarray,
+        coords_2d_gas_rotate: np.ndarray,
+        coords_2d_gas_center: np.ndarray,
+        band: str,
+    ):
+        """Estimate the absolute magnitude and luminosity for a galaxy using galaxev models
+        Parameters:
+        -----------
+        coords_2d_stellar_rotate : np.ndarray
+            Coordinates of the stellar particles after applying the geometric transformations (shape: N_particles x 2) after rotating to the desired orientation.
+            This is needed to calculate the dust attenuation for each particle based on its position in the galaxy and the gas distribution.
+
+        coords_2d_gas_rotate : np.ndarray
+            Rotated 2D coordinates of the gas particles. Shape (N_particles, 2).
+
+        coords_2d_gas_center : np.ndarray
+            Rotated 2D coordinates of the center of the gas distribution. Shape (2,).
+        band : str
+            Photometric band for which to estimate the magnitude and luminosity (e.g., 'g', 'r', 'i', 'u', 'z').
+        """
+
+        # Get stellar particles for this galaxy
+        stellar_particles = self.stellar
+
+        initial_masses = stellar_particles["GFM_InitialMass"]
+        stellar_ages = stellar_particles["Stellar_age"]
+        metallicities_org = stellar_particles["GFM_Metallicity"]
+        ages = np.log10(
+            stellar_ages
+        )  # log10(Gyr). The time when the stars formed. This is consistent with the age grid from galaxev.
+
+        # Calculate dust attenuation based on Xu et al 2017 model https://arxiv.org/abs/1610.07605
+        N_H_cm2, x_edges, y_edges, metallicity_SPH = self.hydrogen_column_density(
+            coords_2d_gas_rotate, coords_2d_gas_center
+        )  # cm^-2
+
+        # masses = stellar_particles["Masses"]
+
+        # Check if there is any dust in the galaxy (i.e., any pixels with N_H > 0). If not, we can skip the dust calculation for all particles which saves a lot of time.
+        has_dust = np.any(N_H_cm2 > 0)
+
+        # The lower and upper bounds of the metallicity grid in the galaxev models. We will clip the metallicities of the stellar
+        # particles to be within these bounds to avoid issues with interpolation. We will also print a warning if any particles are
+        # out of bounds and how many.
+        galaxev_metalicity_limit = [1e-04, 0.1]
+        n_out_of_bounds = np.where(
+            (metallicities_org < galaxev_metalicity_limit[0])
+            | (metallicities_org > galaxev_metalicity_limit[1])
+        )[0]
+
+        if len(n_out_of_bounds) > 0:
+            print(
+                f"Warning: {len(n_out_of_bounds)} stellar particles out of {len(metallicities_org)} have metallicities out of the galaxev model bounds. They will be set to the nearest bound."
+            )
+            metallicities = np.clip(
+                metallicities_org,
+                np.nextafter(galaxev_metalicity_limit[0], np.inf),
+                np.nextafter(galaxev_metalicity_limit[1], -np.inf),
+            )  # The nextafter is to avoid hitting the exact bound which may cause issues with the interpolator
+        else:
+            metallicities = metallicities_org
+
+        # -----------------------------------------------------------------------------
+        # 1. BAND-INDEPENDENT SPATIAL DUST GRID (Calculated exactly once)
+        # -----------------------------------------------------------------------------
+
+        # Project coordinates and pre-calculate spatial indices for ALL particles
+        x_indices_full = np.digitize(coords_2d_stellar_rotate[:, 0], x_edges) - 1
+        y_indices_full = np.digitize(coords_2d_stellar_rotate[:, 1], y_edges) - 1
+
+        # Only apply dust attenuation to particles that fall within the bounds of the N_H grid. This is a simple mask that we can apply to the final dust attenuation values
+        # to set them to zero for particles outside the grid, which avoids any issues with indexing or NaNs.
+        valid_mask_full = (
+            (x_indices_full >= 0)
+            & (x_indices_full < N_H_cm2.shape[0])
+            & (y_indices_full >= 0)
+            & (y_indices_full < N_H_cm2.shape[1])
+        )
+
+        def dust_scatter(
+            wavelength_microns: np.ndarray,
+            has_dust: bool | np.bool_,
+            N_H_cm2: np.ndarray,
+            metallicity_SPH: Optional[np.ndarray] = None,
+        ) -> Optional[np.ndarray]:
+            """Calculate the dust optical depth and scattering for a given wavelength grid. This function is called for each band,
+            but the underlying N_H_cm2 grid is the same for all bands, so we only calculate it once per band.
+
+            Parameters:
+            -----------
+            wavelength_microns : np.ndarray
+                Wavelength grid in microns for the SED within the filter.
+            has_dust : bool | np.bool_
+                Whether there is any dust in the galaxy (i.e., any pixels with N_H > 0).
+            N_H_cm2 : np.ndarray
+                2D grid of hydrogen column density in cm^-2, shape (N_x, N_y).
+            metallicity_SPH : np.ndarray, optional
+                2D grid of metallicity from SPH projection, shape (N_x, N_y). If None, will use mass-averaged metallicity from galaxy data.
+
+            Returns:
+            --------
+            np.ndarray or None
+                3D grid of dust optical depth for the given wavelength grid, shape (N_x, N_y, N_wave), or None if no dust.
+            """
+            if has_dust:
+                if metallicity_SPH is None:
+                    # Using the mass averaged metallcity if the pixel metallicity is not specified.
+                    gas_metallicity = self.subhalo[
+                        "SubhaloGasMetallicity"
+                    ] * np.ones_like(
+                        N_H_cm2
+                    )  # This is the mass-averaged metallicity of the gas in the galaxy, which is a single value for the whole galaxy. We will use this as a fallback if the
+                    # pixel-level metallicity is not available. This is what's done in the Xu+17 paper.
+                else:
+                    gas_metallicity = metallicity_SPH  # Model C in this paper https://arxiv.org/abs/1707.03395. However, to minimize computation time, we use Xu+17's method
+                    # to interpolate on a grid basis instead of per star basis. This means that all stars that fall within the same pixel will have the same dust attenuation,
+                    # which is a good approximation and much faster to compute.
+                if np.isnan(gas_metallicity).any():
+                    gas_metallicity = np.zeros_like(gas_metallicity)
+
+                # The galaxies are at snapshot 99, which corresponds to a redshift of 0.0. The dust extinction calculation will use this redshift not the target redshift,
+                # because the dust is associated with the galaxy itself and should be calculated in the galaxy's rest frame.
+                # The target redshift is only used for scaling the angular size of the galaxy, not for the dust calculation.
+                tau_lambda_a = self.DG2000_optical_depth(
+                    wavelength_microns,
+                    N_H_cm2,
+                    gas_metallicity,
+                    self.subhalo["Redshift"],
+                )
+                tau_lambda = self.CSK1994_scatter(wavelength_microns, tau_lambda_a)
+            else:
+                tau_lambda = None
+
+            return tau_lambda
+
+        N_particles = len(initial_masses)
+        # Fetch user-defined chunk size from config, default to 100,000
+        chunk_size = self.chunk_size
+
+        tau_lambda_all = {}
+        W_dust_map_all = {}
+
+        # Pre-allocate the master 1D output arrays (These use negligible memory)
+
+        self.stellar["Absolute_Magnitude_rotate_" + band] = np.zeros(N_particles)
+        self.stellar["Raw_Luminosity_rotate_" + band] = np.zeros(N_particles)
+        self.stellar["Dusted_Luminosity_rotate_" + band] = np.zeros(N_particles)
+        self.stellar["Dusted_Absolute_Magnitude_rotate_" + band] = np.zeros(N_particles)
+
+        tau_lambda_all[band] = dust_scatter(
+            self.wavelength_SED_within_filter[band]
+            * 1e-4,  # Convert from angstrom to microns
+            has_dust,
+            N_H_cm2,
+            metallicity_SPH=metallicity_SPH,
+        )
+
+        if has_dust and tau_lambda_all[band] is not None:
+            # 1. Calculate A(x,y) = (1 - e^-tau) / tau globally for the unique spatial cells!
+            # Shape: (N_x, N_y, 1851)
+            A_map = np.ones_like(tau_lambda_all[band])
+            valid_tau = tau_lambda_all[band] != 0
+
+            # -expm1(-tau) is mathematically identical to (1 - e^-tau)
+            A_map[valid_tau] = (
+                -np.expm1(-tau_lambda_all[band][valid_tau])
+                / tau_lambda_all[band][valid_tau]
+            )
+
+            # 2. Flip the wavelength axis to perfectly match the L_nu grid
+            A_map_flipped = A_map[:, :, ::-1]
+
+            # 3. Bake the Simpson weights directly into the spatial grid!
+            W_dust_map_all[band] = A_map_flipped * self.numerator_weights[band]
+        else:
+            W_dust_map_all[band] = None
+
+        # -----------------------------------------------------------------------------
+        # 2. PARTICLE CHUNKING LOOP (Strict memory footprint constraint)
+        # -----------------------------------------------------------------------------
+        for start_idx in range(0, N_particles, chunk_size):
+            end_idx = min(start_idx + chunk_size, N_particles)
+
+            # Slice inputs for the current chunk
+            met_chunk = metallicities[start_idx:end_idx]
+            age_chunk = ages[start_idx:end_idx]
+            mass_chunk = initial_masses[start_idx:end_idx]
+
+            print(
+                f"Processing particles {start_idx} to {end_idx} for galaxy ID {self.subhalo['SubhaloID']}"
+            )
+
+            lum_chunk = (
+                numba_bilinear_3d(
+                    met_chunk,
+                    age_chunk,
+                    self.BC03_metallicity_grid,
+                    self.BC03_age_grid_logGr,
+                    self.SED_within_filter_grid[band],
+                )
+                * mass_chunk[
+                    :, None
+                ]  # The BC03 SED grid is in units of luminosity per unit mass, so we multiply by the initial mass of each particle to get the
+                # total luminosity for that particle. The [:, None] adds a new axis so that the multiplication broadcasts correctly to give a shape of
+                # (N_particles_in_chunk, N_wave)
+            )
+
+            # Calulate the raw luminosity by integrating the SED over the filter response using the pre-computed weights. This is a simple dot product along the
+            # wavelength axis, which is very fast and memory efficient.
+            raw_lum_nu = (
+                np.dot(lum_chunk, self.numerator_weights[band])
+                / self.denominator_scalar[band]
+            )
+
+            dusted_lum_nu = raw_lum_nu.copy()
+            if has_dust and W_dust_map_all[band] is not None:
+                mask_chunk = valid_mask_full[start_idx:end_idx]
+                valid_idx = np.where(mask_chunk)[0]
+                if len(valid_idx) > 0:
+                    # Get the x, y coordinates for only the particles inside the map
+                    x_valid = x_indices_full[start_idx:end_idx][valid_idx]
+                    y_valid = y_indices_full[start_idx:end_idx][valid_idx]
+
+                    # Fetch the exact integration weights for these specific particles
+                    # Shape: (N_valid_particles, 1851)
+                    dust_weights = W_dust_map_all[band][x_valid, y_valid]
+
+                    # np.einsum instantly multiplies and sums along the wavelength axis (axis 1)
+                    # This operates in C and allocates ZERO intermediate arrays!
+                    dusted_integrals = np.einsum(
+                        "ij,ij->i", lum_chunk[valid_idx], dust_weights
+                    )
+
+                    dusted_lum_nu[valid_idx] = (
+                        dusted_integrals / self.denominator_scalar[band]
+                    )
+
+            # Convert L_nu (erg/s/Hz) to Absolute Magnitude using the AB magnitude system definition
+            # Wrap the log10 calculations to silence the zero-flux warnings
+            with np.errstate(divide="ignore"):
+                raw_lum_AB_mag = (
+                    -2.5
+                    * np.log10(
+                        raw_lum_nu / (4.0 * np.pi * (10.0 * self.Mpc / 1e6) ** 2)
+                    )
+                    - 48.60
+                )
+                dusted_lum_AB_mag = (
+                    -2.5
+                    * np.log10(
+                        dusted_lum_nu / (4.0 * np.pi * (10.0 * self.Mpc / 1e6) ** 2)
+                    )
+                    - 48.60
+                )
+
+            raw_lum = self.L_sun * 10.0 ** (
+                -0.4 * (raw_lum_AB_mag - self.M_abs_sun[band])
+            )
+            dusted_lum = self.L_sun * 10.0 ** (
+                -0.4 * (dusted_lum_AB_mag - self.M_abs_sun[band])
+            )
+
+            # Store directly into the pre-allocated master 1D arrays
+            # self.stellar_data[galaxy_id]["AB_apparent_magnitude_" + band][
+            #     start_idx:end_idx
+            # ] = app_mag
+            self.stellar["Absolute_Magnitude_rotate_" + band][
+                start_idx:end_idx
+            ] = raw_lum_AB_mag
+            self.stellar["Raw_Luminosity_rotate_" + band][start_idx:end_idx] = raw_lum
+            self.stellar["Dusted_Luminosity_rotate_" + band][
+                start_idx:end_idx
+            ] = dusted_lum
+            self.stellar["Dusted_Absolute_Magnitude_rotate_" + band][
+                start_idx:end_idx
+            ] = dusted_lum_AB_mag
+
+        # -----------------------------------------------------------------------------
+        # 4. GALAXY TOTALS
+        # -----------------------------------------------------------------------------
+
+        total_raw = np.nansum(self.stellar["Raw_Luminosity_rotate_" + band])
+        total_dusted = np.nansum(self.stellar["Dusted_Luminosity_rotate_" + band])
+
+        self.subhalo["Raw_Luminosity_rotate_" + band] = total_raw
+        self.subhalo["Dusted_Luminosity_rotate_" + band] = total_dusted
+
+        self.subhalo["Absolute_Magnitude_rotate_" + band] = -2.5 * np.log10(
+            np.nansum(
+                10.0 ** (-0.4 * self.stellar["Absolute_Magnitude_rotate_" + band])
+            )
+        )
+
+        self.subhalo["Dusted_Absolute_Magnitude_rotate_" + band] = -2.5 * np.log10(
+            np.nansum(
+                10.0
+                ** (-0.4 * self.stellar["Dusted_Absolute_Magnitude_rotate_" + band])
+            )
+        )
+
+        print(f"Total raw luminosity in band {band}: {total_raw} erg/s")
+        print(f"Total dusted luminosity in band {band}: {total_dusted} erg/s")
+        print(
+            f"Dusted absolute magnitude in band {band}: {self.subhalo['Dusted_Absolute_Magnitude_rotate_' + band]} mag"
+        )
+        print(
+            f"Raw absolute magnitude in band {band}: {self.subhalo['Absolute_Magnitude_rotate_' + band]} mag"
+        )
+
+    def hydrogen_column_density(
+        self,
+        coords_rotate_2d_gas: np.ndarray,
+        coords_rotate_2d_gas_center: np.ndarray,
+        max_r: float = 3.0,
+        Ngrid: int = 100,
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Calculate hydrogen column density N_H (cm⁻²) within a given number of grid cells that cover the galaxy.
+        The line-of-sight axis can be specified. The setting for max_r and Ngrid are taken from https://arxiv.org/abs/1610.07605.
+
+        Parameters
+        ----------
+        coords_rotate_2d_gas : np.ndarray
+            Rotated 2D coordinates of the gas particles. Shape (N_particles, 2).
+        coords_rotate_2d_gas_center : np.ndarray
+            Rotated 2D coordinates of the center of the gas distribution. Shape (2,).
+        max_r : float, default=3.0
+            Maximum radius in units of the stellar half-mass radius to define the grid size. The default is taken from Xu et al. 2017, which uses 3 times the stellar
+            half-mass radius to ensure that we capture the majority of the gas and dust in the galaxy while avoiding excessive empty space that would increase
+            computation time.
+        Ngrid : int, default=100
+            Number of grid cells along each axis (total pixels will be Ngrid x Ngrid). The default is taken from Xu et al. 2017, which uses a 100x100 grid to balance
+            resolution and computational efficiency for their sample of TNG galaxies.
+        Returns
+        -------
+        N_H_cm2 : np.ndarray
+            Hydrogen column density in cm⁻².
+        x_edges : np.ndarray
+            Edges of the grid cells along the x-axis.
+        y_edges : np.ndarray
+            Edges of the grid cells along the y-axis.
+        metallicity_sph : np.ndarray
+            Smoothed metallicity distribution using SPH kernel.
+        """
+        # Getting the stellar particles within the same galaxy
+        gas_particles = self.gas
+
+        galaxy_data_single = self.subhalo
+
+        R_eff = galaxy_data_single["SubhaloHalfmassRadStars"]  # kpc
+        galaxy_pos = coords_rotate_2d_gas_center  # kpc
+
+        # --- define grid boundaries ---
+        grid_size = max_r * R_eff  # kpc
+
+        x_edges = np.linspace(
+            galaxy_pos[0] - grid_size, galaxy_pos[0] + grid_size, Ngrid + 1
+        )
+        y_edges = np.linspace(
+            galaxy_pos[1] - grid_size, galaxy_pos[1] + grid_size, Ngrid + 1
+        )
+
+        if gas_particles["Coordinates"] is None:
+            print(f"This galaxy has no gas particles.")
+            N_H_cm2 = np.zeros((Ngrid, Ngrid))
+            metallicity_sph = np.zeros((Ngrid, Ngrid))
+        else:
+            gas_coords = coords_rotate_2d_gas  # kpc
+            gas_masses = gas_particles["Masses"]  # Msun
+            GFM_Metals = gas_particles["GFM_Metals"][
+                :, 0
+            ]  # total hydrogen mass fraction, hydrogen is the first element
+            NeutroHydrogenAbundance = gas_particles[
+                "NeutralHydrogenAbundance"
+            ]  # fraction of neutral hydrogen
+            GFM_Metallicity = gas_particles[
+                "GFM_Metallicity"
+            ]  # total metallicity, which is the mass fraction of all elements heavier than helium
+            # --- project coordinates based on line-of-sight axis ---
+
+            # The neutral hydrogen mass, also the weight.
+            weights = gas_masses * GFM_Metals * NeutroHydrogenAbundance
+            # Using the SPH kernel to smooth the hydrogen mass distribution
+            gas_mass_sph = sph_project_2d(
+                gas_coords[:, 0],
+                gas_coords[:, 1],
+                gas_particles["SubfindHsml"],
+                weights,
+                x_edges,
+                y_edges,
+            )
+
+            metallicity_sph = sph_project_2d(
+                gas_coords[:, 0],
+                gas_coords[:, 1],
+                gas_particles["SubfindHsml"],
+                GFM_Metallicity * weights,
+                x_edges,
+                y_edges,
+            )
+
+            metallicity_sph = np.divide(
+                metallicity_sph,
+                gas_mass_sph,
+                out=np.zeros_like(metallicity_sph),
+                where=gas_mass_sph != 0,
+            )
+
+            dx = np.diff(x_edges)[0]
+            dy = np.diff(y_edges)[0]
+
+            # Mask to find which particles are actually inside our image frame
+            in_bounds = (
+                (gas_coords[:, 0] >= x_edges[0])
+                & (gas_coords[:, 0] <= x_edges[-1])
+                & (gas_coords[:, 1] >= y_edges[0])
+                & (gas_coords[:, 1] <= y_edges[-1])
+            )
+
+            # Only sum the input mass that belongs in the box!
+            total_input = np.sum(weights[in_bounds])
+            total_projected = np.sum(gas_mass_sph) * dx * dy  # Msun
+
+            # SPH does not necessarily conserve mass in each pixel, but it should be close to the total input mass when summed over the whole grid.
+            # We can check this and print a warning if it's not the case, which may indicate an issue with the SPH projection or the choice of grid parameters.
+            if not np.isclose(total_input, total_projected, rtol=5e-2):
+                print(
+                    f"Warning: Mass conserved roughly. Input: {total_input}, Output: {total_projected}"
+                )
+
+            # --- compute per-pixel hydrogen mass in grams ---
+            hydrogen_mass_g = gas_mass_sph * self.Msun_to_g  # g per pixel
+
+            # --- pixel area in cm² ---
+            dx = (x_edges[-1] - x_edges[0]) / Ngrid  # kpc
+            dy = (y_edges[-1] - y_edges[0]) / Ngrid  # kpc
+            area_cm2 = np.float64(dx * dy) * np.float64(self.kpc_to_cm) ** 2  # cm²
+
+            # --- compute number column density ---
+            N_H_cm2 = hydrogen_mass_g / (area_cm2 * self.H_mass)  # cm⁻²
+
+        return N_H_cm2, x_edges, y_edges, metallicity_sph
+
+    def ccm89_av_ratio(self, wavelength_microns: np.ndarray, Rv: float = 3.1):
+        """
+        Compute A(λ)/A(V) using the Cardelli, Clayton & Mathis (1989) extinction law.
+
+        Parameters
+        ----------
+        wavelength_microns : numpy array
+            Wavelength(s) in microns.
+        Rv : float, optional
+            Total-to-selective extinction ratio (default = 3.1 for the diffuse ISM).
+
+        Returns
+        -------
+        A_lambda_over_Av : np.ndarray
+            Extinction curve A(λ)/A(V).
+        """
+        x = 1.0 / np.array(wavelength_microns, ndmin=1)  # inverse microns
+        a = np.zeros_like(x)
+        b = np.zeros_like(x)
+
+        if np.any((x < 0.3) | (x > 10)):
+            print(
+                "Warning: Wavelength out of range for CCM89 extinction law (0.1 - 3.3 microns^-1)."
+            )
+
+        # --- Infrared (0.3 ≤ x < 1.1 μm⁻¹) ---
+        mask_ir = (x >= 0.3) & (x < 1.1)
+        a[mask_ir] = 0.574 * x[mask_ir] ** 1.61
+        b[mask_ir] = -0.527 * x[mask_ir] ** 1.61
+
+        # --- Optical / NIR (1.1 ≤ x < 3.3 μm⁻¹) ---
+        mask_opt = (x >= 1.1) & (x < 3.3)
+        y = x[mask_opt] - 1.82
+        a[mask_opt] = (
+            1
+            + 0.17699 * y
+            - 0.50447 * y**2
+            - 0.02427 * y**3
+            + 0.72085 * y**4
+            + 0.01979 * y**5
+            - 0.77530 * y**6
+            + 0.32999 * y**7
+        )
+        b[mask_opt] = (
+            1.41338 * y
+            + 2.28305 * y**2
+            + 1.07233 * y**3
+            - 5.38434 * y**4
+            - 0.62251 * y**5
+            + 5.30260 * y**6
+            - 2.09002 * y**7
+        )
+
+        # --- Ultraviolet (3.3 ≤ x ≤ 8.0 μm⁻¹) ---
+        mask_uv = (x >= 3.3) & (x <= 8.0)
+        Fa = np.zeros_like(x[mask_uv])
+        Fb = np.zeros_like(x[mask_uv])
+        mask_uv_high = x[mask_uv] >= 5.9
+        if np.any(mask_uv_high):
+            xx = x[mask_uv][mask_uv_high] - 5.9
+            Fa[mask_uv_high] = -0.04473 * xx**2 - 0.009779 * xx**3
+            Fb[mask_uv_high] = 0.2130 * xx**2 + 0.1207 * xx**3
+
+        a[mask_uv] = (
+            1.752 - 0.316 * x[mask_uv] - 0.104 / ((x[mask_uv] - 4.67) ** 2 + 0.341) + Fa
+        )
+        b[mask_uv] = (
+            -3.090
+            + 1.825 * x[mask_uv]
+            + 1.206 / ((x[mask_uv] - 4.62) ** 2 + 0.263)
+            + Fb
+        )
+
+        # --- Far-UV (8.0 < x ≤ 10 μm⁻¹) ---
+        mask_fuv = (x > 8.0) & (x <= 10)
+        a[mask_fuv] = (
+            -1.073
+            - 0.628 * (x[mask_fuv] - 8.0)
+            + 0.137 * (x[mask_fuv] - 8.0) ** 2
+            - 0.070 * (x[mask_fuv] - 8.0) ** 3
+        )
+        b[mask_fuv] = (
+            13.670
+            + 4.257 * (x[mask_fuv] - 8.0)
+            - 0.420 * (x[mask_fuv] - 8.0) ** 2
+            + 0.374 * (x[mask_fuv] - 8.0) ** 3
+        )
+
+        # Final extinction law
+        A_lambda_over_Av = a + b / Rv
+
+        return (
+            A_lambda_over_Av if np.ndim(wavelength_microns) else A_lambda_over_Av.item()
+        )
+
+    def DG2000_optical_depth(
+        self,
+        wavelength_microns: np.ndarray,
+        N_H_cm2: np.ndarray,
+        metallicity: np.ndarray,
+        redshift: float,
+        Z_sun: float = 0.02,
+        beta: float = -0.5,
+        Rv: float = 3.1,
+    ) -> np.ndarray:
+        """
+        Compute the optical depth τ(λ) using the Devriendt & Guiderdoni 2000.
+
+        Parameters
+        ----------
+        wavelength_microns : numpy array
+            Wavelength(s) in microns.
+        N_H_cm2 : numpy array
+            Hydrogen column density in cm⁻².
+        metallicity : numpy array
+            Gas metallicity (mass fraction) of the galaxy.
+        Z_sun : float, optional
+            Solar metallicity (default = 0.02).
+        beta : float, optional
+            Scaling exponent for redshift dependence.
+        Rv : float, optional
+            Total-to-selective extinction ratio for the CCM89 law (default = 3.1).
+
+        Returns
+        -------
+        lambda_tau_no_scatter : numpy array
+            Optical depth τ(λ) without the scattering correction.
+        """
+
+        A_Lambda_over_Av = self.ccm89_av_ratio(wavelength_microns, Rv=Rv)
+        wavelength_angstroms = (
+            np.array(wavelength_microns, ndmin=1) * 1e4
+        )  # Convert microns to angstroms
+        lambda_tau_no_scatter = np.zeros_like(wavelength_angstroms)
+
+        # Power law index s for metallicity dependence from Guiderdoni & Rocca-Volmerange (1987)
+        s = np.zeros_like(wavelength_angstroms)
+        mask1 = wavelength_angstroms <= 2000
+        s[mask1] = 1.35
+        mask2 = wavelength_angstroms > 2000
+        s[mask2] = 1.6
+
+        # Calculating the optical depth τ(λ) without scattering correction
+        lambda_tau_no_scatter = (
+            A_Lambda_over_Av[None, None, :]
+            * N_H_cm2[:, :, None]
+            / (2.1e21)
+            * (1.0 + redshift) ** beta
+            * (metallicity[:, :, None] / Z_sun) ** s[None, None, :]
+        )
+
+        return lambda_tau_no_scatter
+
+    def CSK1994_scatter(
+        self, wavelength_microns: np.ndarray, lambda_tau_no_scatter: np.ndarray
+    ) -> np.ndarray:
+        """
+        Compute the optical depth τ(λ) using the Calzetti, Seaton & Krügel (1994) model after dust scattering.
+
+        Parameters
+        ----------
+        wavelength_microns : float or array-like
+            Wavelength(s) in microns.
+        lambda_tau_no_scatter : numpy array
+            Optical depth τ(λ) without scattering correction, as computed by DG2000_optical_depth().
+
+        Returns
+        -------
+        lambda_tau_scatter : numpy array
+            Optical depth τ(λ) corrected for dust scattering.
+        """
+
+        wavelength_angstroms = (
+            np.array(wavelength_microns, ndmin=1) * 1e4
+        )  # Convert microns to angstroms
+        omega_Lambda = np.zeros_like(wavelength_angstroms)
+        h_Lambda = np.zeros_like(wavelength_angstroms)
+
+        # Calculating the albedo ω(λ) using the Calzetti et al. (1994) empirical fit
+        omega_Lambda = np.zeros_like(wavelength_angstroms)
+        mask1 = (wavelength_angstroms >= 1000) & (wavelength_angstroms <= 3460)
+        y = np.log10(wavelength_angstroms[mask1])
+        omega_Lambda[mask1] = 0.43 + 0.366 * (1.0 - np.exp(-((y - 3.0) ** 2) / 0.2))
+        mask2 = (wavelength_angstroms > 3460) & (wavelength_angstroms <= 7000)
+        y = np.log10(wavelength_angstroms[mask2])
+        omega_Lambda[mask2] = -0.48 * y + 2.41
+
+        # Table of omega_lambda from Natta & Panagia 1984 for wavelength between 0.7 to 4.48 microns
+
+        if np.any((wavelength_angstroms > 7000) & (wavelength_angstroms <= 44800)):
+            print(
+                "Warning: Wavelength out of range for CSK1994 scattering model (0.1 - 0.7 microns). Using Natta & Panagia 1984 table values for longer wavelengths."
+            )
+            omega_table_wavelengths = np.array(
+                [0.7, 0.9, 1.25, 1.65, 2.2, 3.6, 4.48]
+            )  # microns
+
+            omega_table_values = np.array([0.56, 0.50, 0.37, 0.28, 0.22, 0.054, 0.0])
+
+            omega_interp = interp1d(
+                omega_table_wavelengths,
+                omega_table_values,
+                kind="cubic",
+                bounds_error=True,
+                fill_value=None,
+            )
+
+            mask4 = (wavelength_angstroms > 7000) & (wavelength_angstroms <= 44800)
+            omega_Lambda[mask4] = omega_interp(
+                wavelength_angstroms[mask4] / 1e4
+            )  # Convert back to microns for interpolation
+        elif np.any((wavelength_angstroms > 44800) | (wavelength_angstroms < 1000)):
+            print(
+                "Warning: No valid model for wavelength > 4.48 microns or < 0.1 microns in CSK1994 scattering model. Setting albedo to zero."
+            )
+
+        # Calculating the weighting factor h(λ) that accounts for the anistropy in scattering
+        mask3 = (wavelength_angstroms >= 1200) & (wavelength_angstroms <= 7000)
+        y = np.log10(wavelength_angstroms[mask3])
+        h_Lambda[mask3] = 1.0 - 0.561 * np.exp(-(np.abs(y - 3.3112) ** 2.2) / 0.17)
+
+        if np.any((wavelength_angstroms > 7000) & (wavelength_angstroms <= 18000)):
+            print(
+                "Warning: Applying extrapolation for h(λ) beyond 0.7 microns. Bruzual et al 1988 has a table for g(λ) up to 1.8 microns, the functional form seems to hold approximately."
+            )
+
+            mask5 = (wavelength_angstroms > 7000) & (wavelength_angstroms <= 18000)
+            y = np.log10(wavelength_angstroms[mask5])
+            h_Lambda[mask5] = 1.0 - 0.561 * np.exp(-(np.abs(y - 3.3112) ** 2.2) / 0.17)
+        elif np.any(wavelength_angstroms > 18000):
+            print(
+                "Warning: No valid model for h(λ) beyond 1.8 microns in CSK1994 scattering model. Setting h(λ) to one."
+            )
+            mask6 = wavelength_angstroms > 18000
+            h_Lambda[mask6] = 1.0
+        elif np.any(wavelength_angstroms < 1200):
+            print(
+                "Warning: No valid model for h(λ) below 0.12 microns in CSK1994 scattering model. Setting h(λ) to zero."
+            )
+
+        # Correcting the optical depth for scattering effects
+        correction_factor = h_Lambda * np.sqrt(1.0 - omega_Lambda) + (
+            1.0 - h_Lambda
+        ) * (1.0 - omega_Lambda)
+        lambda_tau_scatter = correction_factor[None, None, :] * lambda_tau_no_scatter
+
+        return lambda_tau_scatter
+
     def _compute_disk_rotation_matrices(self):
         """
         Compute rotation matrices to transform from TNG simulation frame to disk frames.
@@ -331,14 +1426,14 @@ class TNGDataVectorGenerator:
         # === Stellar rotation matrix from stellar particles ===
         # Use luminosity-weighted angular momentum for stellar particles
         # This is more physical than SubhaloSpin (which includes all particle types)
-        coords_stellar = self.stellar['Coordinates']
-        vel_stellar = self.stellar['Velocities']
+        coords_stellar = self.stellar["Coordinates"]
+        vel_stellar = self.stellar["Velocities"]
 
         # Use r-band luminosity as weights (or masses if not available)
-        if 'Dusted_Luminosity_r' in self.stellar:
-            weights_stellar = self.stellar['Dusted_Luminosity_r']
-        elif 'Masses' in self.stellar:
-            weights_stellar = self.stellar['Masses']
+        if "Dusted_Luminosity_r" in self.stellar:
+            weights_stellar = self.stellar["Dusted_Luminosity_r"]
+        elif "Masses" in self.stellar:
+            weights_stellar = self.stellar["Masses"]
         else:
             weights_stellar = np.ones(len(coords_stellar))
 
@@ -366,10 +1461,10 @@ class TNGDataVectorGenerator:
         self._kinematic_inc_stellar_deg = np.rad2deg(np.arccos(np.abs(L_stellar[2])))
 
         # === Gas rotation matrix from particle angular momentum ===
-        if self.gas is not None and len(self.gas.get('Coordinates', [])) > 0:
-            coords_gas = self.gas['Coordinates']
-            vel_gas = self.gas['Velocities']
-            masses_gas = self.gas['Masses']
+        if self.gas is not None and len(self.gas.get("Coordinates", [])) > 0:
+            coords_gas = self.gas["Coordinates"]
+            vel_gas = self.gas["Velocities"]
+            masses_gas = self.gas["Masses"]
 
             # Center on mass-weighted centroid
             center_gas = np.average(coords_gas, axis=0, weights=masses_gas)
@@ -453,14 +1548,20 @@ class TNGDataVectorGenerator:
         # R = I + sin(θ)K + (1-cos(θ))K²
         return np.eye(3) + np.sin(angle) * K + (1 - cos_angle) * (K @ K)
 
-    def _get_luminosity_key(self, band: str, use_dusted: bool) -> str:
+    def _get_luminosity_key(
+        self, band: str, use_dusted: bool, rotate: bool = False
+    ) -> str:
         """Get the appropriate luminosity key for the specified band."""
-        prefix = 'Dusted_Luminosity' if use_dusted else 'Raw_Luminosity'
-        key = f'{prefix}_{band}'
-
+        prefix = "Dusted_Luminosity" if use_dusted else "Raw_Luminosity"
+        if rotate and use_dusted:
+            prefix += "_rotate"
+        key = f"{prefix}_{band}"
+        # Use the dusted luminosity after the rotation since the dust attenuation depends on the line-of-sight, so the luminosity values will change after the rotation.
+        # The raw luminosity is unaffected by the rotation since it is intrinsic to the stellar population, so we can use the same raw luminosity values before and
+        # after the rotation.
         # Validate key exists
         if key not in self.stellar:
-            available = [k for k in self.stellar.keys() if 'Luminosity' in k]
+            available = [k for k in self.stellar.keys() if "Luminosity" in k]
             raise KeyError(
                 f"Luminosity key '{key}' not found in stellar data. "
                 f"Available bands: {available}"
@@ -469,7 +1570,7 @@ class TNGDataVectorGenerator:
         return key
 
     def _get_reference_center(
-        self, center_on_peak: bool, band: str = 'r', use_dusted: bool = True
+        self, center_on_peak: bool, band: str = "r", use_dusted: bool = True
     ) -> np.ndarray:
         """
         Get reference center for coordinate system (shared by intensity and velocity).
@@ -495,15 +1596,15 @@ class TNGDataVectorGenerator:
             # Use stellar luminosity-weighted centroid as reference
             lum_key = self._get_luminosity_key(band, use_dusted)
             luminosities = self.stellar[lum_key]
-            stellar_coords = self.stellar['Coordinates']
+            stellar_coords = self.stellar["Coordinates"]
             center = np.average(stellar_coords, axis=0, weights=luminosities)
         else:
             # Use subhalo position
             center = np.array(
                 [
-                    self.subhalo['SubhaloPosX'],
-                    self.subhalo['SubhaloPosY'],
-                    self.subhalo['SubhaloPosZ'],
+                    self.subhalo["SubhaloPosX"],
+                    self.subhalo["SubhaloPosY"],
+                    self.subhalo["SubhaloPosZ"],
                 ]
             )
         return center
@@ -527,7 +1628,7 @@ class TNGDataVectorGenerator:
         return coords - center
 
     def _undo_native_orientation(
-        self, coords: np.ndarray, velocities: np.ndarray, particle_type: str = 'stellar'
+        self, coords: np.ndarray, velocities: np.ndarray, particle_type: str = "stellar"
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         Transform from TNG's native obs frame to face-on disk plane.
@@ -559,7 +1660,7 @@ class TNGDataVectorGenerator:
             Velocities in face-on disk plane, shape (n_particles, 3)
         """
         # Select the appropriate rotation matrix
-        if particle_type == 'gas':
+        if particle_type == "gas":
             R = self._R_to_disk_gas
         else:
             R = self._R_to_disk_stellar
@@ -605,12 +1706,12 @@ class TNGDataVectorGenerator:
             3D coordinates in new obs frame (for diagnostics), shape (n_particles, 3)
         """
         # Extract parameters with defaults
-        cosi = pars.get('cosi', 1.0)
-        theta_int = pars.get('theta_int', 0.0)
-        x0 = pars.get('x0', 0.0)
-        y0 = pars.get('y0', 0.0)
-        g1 = pars.get('g1', 0.0)
-        g2 = pars.get('g2', 0.0)
+        cosi = pars.get("cosi", 1.0)
+        theta_int = pars.get("theta_int", 0.0)
+        x0 = pars.get("x0", 0.0)
+        y0 = pars.get("y0", 0.0)
+        g1 = pars.get("g1", 0.0)
+        g2 = pars.get("g2", 0.0)
 
         # Validate shear parameters
         gamma = np.sqrt(g1**2 + g2**2)
@@ -709,7 +1810,7 @@ class TNGDataVectorGenerator:
         values: np.ndarray,
         weights: np.ndarray,
         image_pars: ImagePars,
-        mode: str = 'weighted_average',
+        mode: str = "weighted_average",
     ) -> np.ndarray:
         """
         Grid particles using Cloud-in-Cell (CIC) interpolation.
@@ -737,11 +1838,11 @@ class TNGDataVectorGenerator:
             Gridded 2D map, shape determined by image_pars
         """
         # Get grid properties
-        X, Y = build_map_grid_from_image_pars(image_pars, unit='arcsec', centered=True)
+        X, Y = build_map_grid_from_image_pars(image_pars, unit="arcsec", centered=True)
         pixel_size = image_pars.pixel_scale
         Ny, Nx = (
             image_pars.shape
-            if image_pars.indexing == 'ij'
+            if image_pars.indexing == "ij"
             else (image_pars.shape[1], image_pars.shape[0])
         )
 
@@ -752,7 +1853,7 @@ class TNGDataVectorGenerator:
 
         # Initialize arrays
         weighted_sum = np.zeros((Ny, Nx))
-        weight_sum = np.zeros((Ny, Nx)) if mode == 'weighted_average' else None
+        weight_sum = np.zeros((Ny, Nx)) if mode == "weighted_average" else None
 
         # Cloud-in-Cell: distribute to 4 nearest pixels
         x_floor = np.floor(x_pix).astype(int)
@@ -796,13 +1897,13 @@ class TNGDataVectorGenerator:
                     values_valid * weights_valid * w_valid,
                 )
 
-                if mode == 'weighted_average':
+                if mode == "weighted_average":
                     np.add.at(weight_sum, (yi_valid, xi_valid), weights_valid * w_valid)
 
         # Compute result based on mode
-        if mode == 'sum':
+        if mode == "sum":
             result = weighted_sum
-        elif mode == 'weighted_average':
+        elif mode == "weighted_average":
             mask = weight_sum > 0
             result = np.zeros((Ny, Nx))
             result[mask] = weighted_sum[mask] / weight_sum[mask]
@@ -817,7 +1918,7 @@ class TNGDataVectorGenerator:
         values: np.ndarray,
         weights: np.ndarray,
         image_pars: ImagePars,
-        mode: str = 'weighted_average',
+        mode: str = "weighted_average",
     ) -> np.ndarray:
         """
         Grid particles using nearest-grid-point (NGP) assignment.
@@ -843,11 +1944,11 @@ class TNGDataVectorGenerator:
         np.ndarray
             Gridded 2D map, shape determined by image_pars
         """
-        X, Y = build_map_grid_from_image_pars(image_pars, unit='arcsec', centered=True)
+        X, Y = build_map_grid_from_image_pars(image_pars, unit="arcsec", centered=True)
         pixel_size = image_pars.pixel_scale
         Ny, Nx = (
             image_pars.shape
-            if image_pars.indexing == 'ij'
+            if image_pars.indexing == "ij"
             else (image_pars.shape[1], image_pars.shape[0])
         )
 
@@ -864,9 +1965,9 @@ class TNGDataVectorGenerator:
             weights=values * weights,
         )
 
-        if mode == 'sum':
+        if mode == "sum":
             result = H_weighted
-        elif mode == 'weighted_average':
+        elif mode == "weighted_average":
             H_weights, _, _ = np.histogram2d(
                 y_pix, x_pix, bins=[Ny, Nx], range=[[0, Ny], [0, Nx]], weights=weights
             )
@@ -904,16 +2005,9 @@ class TNGDataVectorGenerator:
         variance : np.ndarray
             Variance map, shape from image_pars
         """
-        # Get luminosity weights
-        lum_key = self._get_luminosity_key(config.band, config.use_dusted)
-        luminosities = self.stellar[lum_key]
-
-        # Normalize to avoid overflow (will rescale back later)
-        lum_scale = luminosities.max()
-        luminosities_norm = luminosities / lum_scale
 
         # Get coordinates
-        coords = self.stellar['Coordinates'].copy()
+        coords = self.stellar["Coordinates"].copy()
 
         # Get reference center (shared with velocity map for consistent FOV)
         center = self._get_reference_center(
@@ -934,7 +2028,7 @@ class TNGDataVectorGenerator:
 
             # Undo native orientation to get face-on stellar disk
             coords_disk, _ = self._undo_native_orientation(
-                coords_centered, np.zeros_like(coords_centered), particle_type='stellar'
+                coords_centered, np.zeros_like(coords_centered), particle_type="stellar"
             )
 
             # Apply new stellar orientation from pars
@@ -942,9 +2036,50 @@ class TNGDataVectorGenerator:
                 coords_disk, np.zeros_like(coords_disk), config.pars
             )
 
+            if config.use_dusted:
+                # If using the dusted luminosity, we also need to apply the same rotation for the gas particles.
+                # This is because the dust attenuation depends on the line-of-sight, so the luminosity values will change after the rotation.
+                # We apply the same rotation to the gas particles to ensure that the dust attenuation is consistent with the new orientation of the stellar particles.
+                coords_gas = self.gas["Coordinates"].copy()
+                center_gas = self._get_reference_center(
+                    config.center_on_peak, config.band, config.use_dusted
+                )
+                coords_gas_centered = self._center_coordinates(coords_gas, center_gas)
+                coords_gas_disk, _ = self._undo_native_orientation(
+                    coords_gas_centered,
+                    np.zeros_like(coords_gas_centered),
+                    particle_type="gas",
+                )
+                coords_gas_2d, _, _ = self._apply_new_orientation(
+                    coords_gas_disk, np.zeros_like(coords_gas_disk), config.pars
+                )
+
+                # The 2d coordinates have already subtracted the center, so we can just pass in np.array([0.0, 0.0]) for the center in the luminosity estimation.
+                self._estimate_magnitude_luminosity(
+                    coords_2d, coords_gas_2d, np.array([0.0, 0.0]), config.band
+                )
+
+        # Get luminosity weights
+        lum_key = self._get_luminosity_key(
+            config.band, config.use_dusted, rotate=not config.use_native_orientation
+        )
+        luminosities = self.stellar[lum_key]
+
+        # Normalize to avoid overflow (will rescale back later)
+        lum_scale = luminosities.max()
+        luminosities_norm = luminosities / lum_scale
+
         # Convert to arcsec (with optional redshift scaling)
         coords_arcsec = convert_tng_to_arcsec(
-            coords_2d, self.distance_mpc, target_redshift=config.target_redshift
+            coords_2d, target_redshift=config.target_redshift
+        )
+
+        print(
+            config.target_redshift,
+            np.min(coords_2d),
+            np.max(coords_2d),
+            np.min(coords_arcsec),
+            np.max(coords_arcsec),
         )
 
         # Grid luminosities (sum, not weighted average)
@@ -954,7 +2089,7 @@ class TNGDataVectorGenerator:
                 luminosities_norm,
                 np.ones_like(luminosities_norm),
                 config.image_pars,
-                mode='sum',
+                mode="sum",
             )
         else:
             intensity = self._grid_particles_ngp(
@@ -962,7 +2097,7 @@ class TNGDataVectorGenerator:
                 luminosities_norm,
                 np.ones_like(luminosities_norm),
                 config.image_pars,
-                mode='sum',
+                mode="sum",
             )
 
         # Rescale back to original units
@@ -1030,9 +2165,9 @@ class TNGDataVectorGenerator:
         if self.gas is None:
             raise ValueError("Gas data required for velocity map generation")
 
-        coords = self.gas['Coordinates'].copy()
-        velocities = self.gas['Velocities'].copy()
-        masses = self.gas['Masses'].copy()
+        coords = self.gas["Coordinates"].copy()
+        velocities = self.gas["Velocities"].copy()
+        masses = self.gas["Masses"].copy()
 
         # Subtract systemic velocity using mass-weighted mean of inner region
         # Use only inner particles to avoid bias from distant satellites/CGM
@@ -1081,10 +2216,10 @@ class TNGDataVectorGenerator:
             #   User's (cosi, theta_int) refers to each component independently.
             if config.preserve_gas_stellar_offset:
                 # Use stellar rotation for gas -> preserves intrinsic misalignment
-                particle_type = 'stellar'
+                particle_type = "stellar"
             else:
                 # Use gas's own rotation -> aligns gas with user's requested orientation
-                particle_type = 'gas'
+                particle_type = "gas"
 
             # Undo native orientation to get face-on disk
             coords_disk, velocities_disk = self._undo_native_orientation(
@@ -1098,7 +2233,7 @@ class TNGDataVectorGenerator:
 
         # Convert to arcsec (with optional redshift scaling)
         coords_arcsec = convert_tng_to_arcsec(
-            coords_2d, self.distance_mpc, target_redshift=config.target_redshift
+            coords_2d, target_redshift=config.target_redshift
         )
 
         # Grid velocities (mass-weighted average for gas)
@@ -1108,7 +2243,7 @@ class TNGDataVectorGenerator:
                 vel_los,
                 masses_norm,
                 config.image_pars,
-                mode='weighted_average',
+                mode="weighted_average",
             )
         else:
             velocity = self._grid_particles_ngp(
@@ -1116,7 +2251,7 @@ class TNGDataVectorGenerator:
                 vel_los,
                 masses_norm,
                 config.image_pars,
-                mode='weighted_average',
+                mode="weighted_average",
             )
 
         # Apply flux-weighted PSF convolution if requested
@@ -1179,10 +2314,10 @@ class TNGDataVectorGenerator:
         from ..noise import add_noise
 
         # Get star formation rates (Msun/yr per particle)
-        sfr = self.gas['StarFormationRate'].copy()
+        sfr = self.gas["StarFormationRate"].copy()
 
         # Get coordinates
-        coords = self.gas['Coordinates'].copy()
+        coords = self.gas["Coordinates"].copy()
 
         # Get reference center (use stellar peak for consistency with intensity)
         center = self._get_reference_center(
@@ -1204,7 +2339,7 @@ class TNGDataVectorGenerator:
             # Undo native GAS orientation to get face-on gas disk
             # Uses the gas-specific angular momentum rotation matrix
             coords_disk, _ = self._undo_native_orientation(
-                coords_centered, np.zeros_like(coords_centered), particle_type='gas'
+                coords_centered, np.zeros_like(coords_centered), particle_type="gas"
             )
 
             # Apply requested orientation (same as velocity - uses gas angular momentum)
@@ -1214,17 +2349,17 @@ class TNGDataVectorGenerator:
 
         # Convert to arcsec (with optional redshift scaling)
         coords_arcsec = convert_tng_to_arcsec(
-            coords_2d, self.distance_mpc, target_redshift=config.target_redshift
+            coords_2d, target_redshift=config.target_redshift
         )
 
         # Grid SFR (sum to get total SFR per pixel)
         if config.use_cic_gridding:
             sfr_map = self._grid_particles_cic(
-                coords_arcsec, sfr, np.ones_like(sfr), config.image_pars, mode='sum'
+                coords_arcsec, sfr, np.ones_like(sfr), config.image_pars, mode="sum"
             )
         else:
             sfr_map = self._grid_particles_ngp(
-                coords_arcsec, sfr, np.ones_like(sfr), config.image_pars, mode='sum'
+                coords_arcsec, sfr, np.ones_like(sfr), config.image_pars, mode="sum"
             )
 
         # Apply cosmological surface brightness dimming if requested

--- a/kl_pipe/tng/data_vectors.py
+++ b/kl_pipe/tng/data_vectors.py
@@ -8,8 +8,8 @@ noise and observational effects.
 ## Coordinate Systems
 
 **TNG Native Frame:**
-- Origin: Simulation box coordinates (comoving kpc/h)
-- Units: Comoving kpc/h (need conversion via Hubble parameter)
+- Origin: output TNG data catalogue (comoving kpc)
+- Units: Comoving kpc (need conversion via Hubble parameter)
 - Orientation: As simulated (intrinsic Inclination_star, Position_Angle_star)
 
 **Observer Frame (after rendering):**
@@ -34,12 +34,12 @@ For TNG galaxies:
 
 **Stellar Data:**
 - Luminosities: ~10^36-10^38 erg/s (band-dependent)
-- Coordinates: Comoving kpc/h
+- Coordinates: Comoving kpc
 - Velocities: km/s (peculiar velocities)
 
 **Gas Data:**
 - Masses: 10^4-10^6 Msun (typical resolution)
-- Coordinates: Comoving kpc/h
+- Coordinates: Comoving kpc
 - Velocities: km/s (peculiar velocities)
 
 **Rendered Maps:**
@@ -95,12 +95,19 @@ import numpy as np
 from dataclasses import dataclass
 from astropy.cosmology import FlatLambdaCDM
 from astropy import units as u
-from numba import njit, prange
+
+# from numba import njit, prange
 from scipy.integrate import simpson
 import h5py
 from scipy.interpolate import interp1d
 from pathlib import Path
 
+from .tng_dust import (
+    numba_bilinear_3d,
+    sph_project_2d,
+    DG2000_optical_depth,
+    CSK1994_scatter,
+)
 from ..parameters import ImagePars
 from ..utils import build_map_grid_from_image_pars
 from ..noise import add_noise
@@ -181,287 +188,6 @@ def convert_tng_to_arcsec(
         )
 
     return coords_arcsec
-
-
-# -------------------------------------------------------------------------
-# 1. THE 3D SED KERNEL. Using numba to unroll the for loops and do the interpolation purely in the CPU cache for maximum speed.
-# -------------------------------------------------------------------------
-@njit(parallel=True, fastmath=True)
-def numba_bilinear_3d(
-    met_chunk: np.ndarray,
-    age_chunk: np.ndarray,
-    met_grid: np.ndarray,
-    age_grid: np.ndarray,
-    band_grid: np.ndarray,
-) -> np.ndarray:
-    """Bilinear interpolation in 2D (metallicity, age) for each particle to get SED for a specific band. Returns array of shape (N_particles, N_wave) with interpolated SEDs.
-
-    The input metallicity is the mass metallicity ratio from the TNG simulation. Not solar metallicity. The input age is in Gyr.
-    Parameters
-    ----------
-    met_chunk : np.ndarray
-        Metallicity values for each particle
-    age_chunk : np.ndarray
-        Age values for each particle
-    met_grid : np.ndarray
-        Grid of metallicity values
-    age_grid : np.ndarray
-        Grid of age values
-    band_grid : np.ndarray
-        Grid of SED values for a specific band, shape (N_met, N_age, N_wave)
-
-    Returns
-    -------
-    np.ndarray
-        Interpolated SEDs for each particle
-    """
-
-    N_particles = len(met_chunk)
-    N_wave = band_grid.shape[2]
-
-    # Pre-allocate the ONLY array that gets written to RAM
-    out_seds = np.empty((N_particles, N_wave), dtype=band_grid.dtype)
-
-    # prange splits the 100,000 particles across your CPU cores!
-    for i in prange(N_particles):
-        met = met_chunk[i]
-        age = age_chunk[i]
-
-        # Numba perfectly supports np.searchsorted
-        idx_met = np.searchsorted(met_grid, met) - 1
-        idx_age = np.searchsorted(age_grid, age) - 1
-
-        # Numba doesn't like np.clip on scalars, so we write explicit bounds
-        if idx_met < 0:
-            idx_met = 0
-        if idx_met > len(met_grid) - 2:
-            idx_met = len(met_grid) - 2
-        if idx_age < 0:
-            idx_age = 0
-        if idx_age > len(age_grid) - 2:
-            idx_age = len(age_grid) - 2
-
-        met1 = met_grid[idx_met]
-        met2 = met_grid[idx_met + 1]
-        age1 = age_grid[idx_age]
-        age2 = age_grid[idx_age + 1]
-
-        tx = (met - met1) / (met2 - met1)
-        ty = (age - age1) / (age2 - age1)
-
-        if tx < 0.0:
-            tx = 0.0
-        if tx > 1.0:
-            tx = 1.0
-        if ty < 0.0:
-            ty = 0.0
-        if ty > 1.0:
-            ty = 1.0
-
-        # Weights for the four corners of the grid cell
-        w11 = (1.0 - tx) * (1.0 - ty)
-        w21 = tx * (1.0 - ty)
-        w12 = (1.0 - tx) * ty
-        w22 = tx * ty
-
-        # THE MAGIC: Loop over wavelengths purely inside the CPU cache!
-        for j in range(N_wave):
-            out_seds[i, j] = (
-                band_grid[idx_met, idx_age, j] * w11
-                + band_grid[idx_met + 1, idx_age, j] * w21
-                + band_grid[idx_met, idx_age + 1, j] * w12
-                + band_grid[idx_met + 1, idx_age + 1, j] * w22
-            )
-
-    return out_seds
-
-
-# -------------------------------------------------------------------------
-# 2. THE 2D ABSOLUTE MAGNITUDE KERNEL. Similar to the 3D SED kernel but simpler since the grid is only 2D (metallicity, age) and the output is a single magnitude value
-# for each particle instead of a full SED. Still uses numba for speed.
-# -------------------------------------------------------------------------
-@njit(parallel=True, fastmath=True)
-def numba_bilinear_2d(
-    met_chunk: np.ndarray,
-    age_chunk: np.ndarray,
-    met_grid: np.ndarray,
-    age_grid: np.ndarray,
-    band_grid: np.ndarray,
-) -> np.ndarray:
-    """Bilinear interpolation in 2D (metallicity, age) for each particle to get absolute magnitude for a specific band. Returns array of shape (N_particles,)
-    with interpolated magnitudes.
-
-    The input metallicity is the mass metallicity ratio from the TNG simulation. Not solar metallicity. The input age is in Gyr.
-    Parameters
-    ----------
-    met_chunk : np.ndarray
-        Metallicity values for each particle
-    age_chunk : np.ndarray
-        Age values for each particle
-    met_grid : np.ndarray
-        Grid of metallicity values
-    age_grid : np.ndarray
-        Grid of age values
-    band_grid : np.ndarray
-        Grid of absolute magnitudes for a specific band, shape (N_met, N_age)
-
-    Returns
-    -------
-    np.ndarray
-        Interpolated magnitudes for each particle
-    """
-    N_particles = len(met_chunk)
-    out_mags = np.empty(N_particles, dtype=band_grid.dtype)
-
-    for i in prange(N_particles):
-        met = met_chunk[i]
-        age = age_chunk[i]
-
-        idx_met = np.searchsorted(met_grid, met) - 1
-        idx_age = np.searchsorted(age_grid, age) - 1
-
-        if idx_met < 0:
-            idx_met = 0
-        if idx_met > len(met_grid) - 2:
-            idx_met = len(met_grid) - 2
-        if idx_age < 0:
-            idx_age = 0
-        if idx_age > len(age_grid) - 2:
-            idx_age = len(age_grid) - 2
-
-        met1 = met_grid[idx_met]
-        met2 = met_grid[idx_met + 1]
-        age1 = age_grid[idx_age]
-        age2 = age_grid[idx_age + 1]
-
-        tx = (met - met1) / (met2 - met1)
-        ty = (age - age1) / (age2 - age1)
-
-        if tx < 0.0:
-            tx = 0.0
-        if tx > 1.0:
-            tx = 1.0
-        if ty < 0.0:
-            ty = 0.0
-        if ty > 1.0:
-            ty = 1.0
-
-        w11 = (1.0 - tx) * (1.0 - ty)
-        w21 = tx * (1.0 - ty)
-        w12 = (1.0 - tx) * ty
-        w22 = tx * ty
-
-        out_mags[i] = (
-            band_grid[idx_met, idx_age] * w11
-            + band_grid[idx_met + 1, idx_age] * w21
-            + band_grid[idx_met, idx_age + 1] * w12
-            + band_grid[idx_met + 1, idx_age + 1] * w22
-        )
-
-    return out_mags
-
-
-@njit(fastmath=True)
-def sph_project_2d(
-    x: np.ndarray,
-    y: np.ndarray,
-    h_tng: np.ndarray,
-    weights: np.ndarray,
-    x_edges: np.ndarray,
-    y_edges: np.ndarray,
-) -> np.ndarray:
-    """
-    2D SPH projection using cubic spline kernel. This is the core of the gridding process, where we take particle positions, smoothing lengths, and weights
-    (e.g., luminosities or masses) and project them onto a 2D pixel grid defined by x_edges and y_edges. Using numba to speed up the nested loops and avoid temporary arrays
-    for maximum performance.
-
-    Parameters:
-    x : np.ndarray
-        X coordinates of particles in kpc
-    y : np.ndarray
-        Y coordinates of particles in kpc
-    h_tng : np.ndarray
-        Smoothing lengths of particles in kpc (TNG defines Hsml as the full support radius, so we divide by 2 in the code to get the "h" used in the kernel)
-    weights : np.ndarray
-        Weights of particles (e.g., luminosities or masses)
-    x_edges : np.ndarray
-        Edges of the pixel grid in the X direction
-    y_edges : np.ndarray
-        Edges of the pixel grid in the Y direction
-
-    Returns
-    -------
-    np.ndarray
-        2D grid with projected values
-
-    """
-
-    nx = len(x_edges) - 1
-    ny = len(y_edges) - 1
-    grid = np.zeros((nx, ny))
-
-    dx = x_edges[1] - x_edges[0]
-    dy = y_edges[1] - y_edges[0]
-
-    x_centers = 0.5 * (x_edges[:-1] + x_edges[1:])
-    y_centers = 0.5 * (y_edges[:-1] + y_edges[1:])
-
-    for i in range(len(x)):
-        xi, yi = x[i], y[i]
-        # TNG defines Hsml as the full support radius. Our math expects half of that.
-        hi = h_tng[i] / 2.0
-        wi = weights[i]
-
-        if hi <= 0:
-            continue
-
-        # Handle Undersampling: If the particle is smaller than a pixel, dump it as a point mass
-        if hi < 0.5 * min(dx, dy):
-            ix = np.searchsorted(x_edges, xi) - 1
-            iy = np.searchsorted(y_edges, yi) - 1
-
-            if 0 <= ix < nx and 0 <= iy < ny:
-                # Convert mass to surface density
-                grid[ix, iy] += wi / (dx * dy)
-            continue
-
-        # Determine affected pixel range
-        x_min = xi - 2 * hi
-        x_max = xi + 2 * hi
-        y_min = yi - 2 * hi
-        y_max = yi + 2 * hi
-
-        ix_min = np.searchsorted(x_centers, x_min, side='left')
-        ix_max = np.searchsorted(x_centers, x_max, side='right')
-        iy_min = np.searchsorted(y_centers, y_min, side='left')
-        iy_max = np.searchsorted(y_centers, y_max, side='right')
-
-        ix_min = max(ix_min, 0)
-        ix_max = min(ix_max, nx)
-        iy_min = max(iy_min, 0)
-        iy_max = min(iy_max, ny)
-
-        # The 2D cubic spline normalization factor
-        norm = 10.0 / (7.0 * np.pi * hi**2)
-
-        # Pure scalar nested loops (Zero temporary arrays!)
-        for ix in range(ix_min, ix_max):
-            dx_pos = x_centers[ix] - xi
-
-            for iy in range(iy_min, iy_max):
-                dy_pos = y_centers[iy] - yi
-
-                r = np.sqrt(dx_pos**2 + dy_pos**2)
-                q = r / hi
-
-                if q < 1.0:
-                    w_val = norm * (1.0 - 1.5 * q**2 + 0.75 * q**3)
-                    grid[ix, iy] += wi * w_val
-                elif q < 2.0:
-                    w_val = norm * (0.25 * (2.0 - q) ** 3)
-                    grid[ix, iy] += wi * w_val
-
-    return grid
 
 
 @dataclass
@@ -842,13 +568,13 @@ class TNGDataVectorGenerator:
                 # The galaxies are at snapshot 99, which corresponds to a redshift of 0.0. The dust extinction calculation will use this redshift not the target redshift,
                 # because the dust is associated with the galaxy itself and should be calculated in the galaxy's rest frame.
                 # The target redshift is only used for scaling the angular size of the galaxy, not for the dust calculation.
-                tau_lambda_a = self.DG2000_optical_depth(
+                tau_lambda_a = DG2000_optical_depth(
                     wavelength_microns,
                     N_H_cm2,
                     gas_metallicity,
                     self.subhalo['Redshift'],
                 )
-                tau_lambda = self.CSK1994_scatter(wavelength_microns, tau_lambda_a)
+                tau_lambda = CSK1994_scatter(wavelength_microns, tau_lambda_a)
             else:
                 tau_lambda = None
 
@@ -1161,254 +887,6 @@ class TNGDataVectorGenerator:
             N_H_cm2 = hydrogen_mass_g / (area_cm2 * self.H_mass)  # cm⁻²
 
         return N_H_cm2, x_edges, y_edges, metallicity_sph
-
-    def ccm89_av_ratio(self, wavelength_microns: np.ndarray, Rv: float = 3.1):
-        """
-        Compute A(λ)/A(V) using the Cardelli, Clayton & Mathis (1989) extinction law.
-
-        Parameters
-        ----------
-        wavelength_microns : numpy array
-            Wavelength(s) in microns.
-        Rv : float, optional
-            Total-to-selective extinction ratio (default = 3.1 for the diffuse ISM).
-
-        Returns
-        -------
-        A_lambda_over_Av : np.ndarray
-            Extinction curve A(λ)/A(V).
-        """
-        x = 1.0 / np.array(wavelength_microns, ndmin=1)  # inverse microns
-        a = np.zeros_like(x)
-        b = np.zeros_like(x)
-
-        if np.any((x < 0.3) | (x > 10)):
-            print(
-                'Warning: Wavelength out of range for CCM89 extinction law (0.1 - 3.3 microns^-1).'
-            )
-
-        # --- Infrared (0.3 ≤ x < 1.1 μm⁻¹) ---
-        mask_ir = (x >= 0.3) & (x < 1.1)
-        a[mask_ir] = 0.574 * x[mask_ir] ** 1.61
-        b[mask_ir] = -0.527 * x[mask_ir] ** 1.61
-
-        # --- Optical / NIR (1.1 ≤ x < 3.3 μm⁻¹) ---
-        mask_opt = (x >= 1.1) & (x < 3.3)
-        y = x[mask_opt] - 1.82
-        a[mask_opt] = (
-            1
-            + 0.17699 * y
-            - 0.50447 * y**2
-            - 0.02427 * y**3
-            + 0.72085 * y**4
-            + 0.01979 * y**5
-            - 0.77530 * y**6
-            + 0.32999 * y**7
-        )
-        b[mask_opt] = (
-            1.41338 * y
-            + 2.28305 * y**2
-            + 1.07233 * y**3
-            - 5.38434 * y**4
-            - 0.62251 * y**5
-            + 5.30260 * y**6
-            - 2.09002 * y**7
-        )
-
-        # --- Ultraviolet (3.3 ≤ x ≤ 8.0 μm⁻¹) ---
-        mask_uv = (x >= 3.3) & (x <= 8.0)
-        Fa = np.zeros_like(x[mask_uv])
-        Fb = np.zeros_like(x[mask_uv])
-        mask_uv_high = x[mask_uv] >= 5.9
-        if np.any(mask_uv_high):
-            xx = x[mask_uv][mask_uv_high] - 5.9
-            Fa[mask_uv_high] = -0.04473 * xx**2 - 0.009779 * xx**3
-            Fb[mask_uv_high] = 0.2130 * xx**2 + 0.1207 * xx**3
-
-        a[mask_uv] = (
-            1.752 - 0.316 * x[mask_uv] - 0.104 / ((x[mask_uv] - 4.67) ** 2 + 0.341) + Fa
-        )
-        b[mask_uv] = (
-            -3.090
-            + 1.825 * x[mask_uv]
-            + 1.206 / ((x[mask_uv] - 4.62) ** 2 + 0.263)
-            + Fb
-        )
-
-        # --- Far-UV (8.0 < x ≤ 10 μm⁻¹) ---
-        mask_fuv = (x > 8.0) & (x <= 10)
-        a[mask_fuv] = (
-            -1.073
-            - 0.628 * (x[mask_fuv] - 8.0)
-            + 0.137 * (x[mask_fuv] - 8.0) ** 2
-            - 0.070 * (x[mask_fuv] - 8.0) ** 3
-        )
-        b[mask_fuv] = (
-            13.670
-            + 4.257 * (x[mask_fuv] - 8.0)
-            - 0.420 * (x[mask_fuv] - 8.0) ** 2
-            + 0.374 * (x[mask_fuv] - 8.0) ** 3
-        )
-
-        # Final extinction law
-        A_lambda_over_Av = a + b / Rv
-
-        return (
-            A_lambda_over_Av if np.ndim(wavelength_microns) else A_lambda_over_Av.item()
-        )
-
-    def DG2000_optical_depth(
-        self,
-        wavelength_microns: np.ndarray,
-        N_H_cm2: np.ndarray,
-        metallicity: np.ndarray,
-        redshift: float,
-        Z_sun: float = 0.02,
-        beta: float = -0.5,
-        Rv: float = 3.1,
-    ) -> np.ndarray:
-        """
-        Compute the optical depth τ(λ) using the Devriendt & Guiderdoni 2000.
-
-        Parameters
-        ----------
-        wavelength_microns : numpy array
-            Wavelength(s) in microns.
-        N_H_cm2 : numpy array
-            Hydrogen column density in cm⁻².
-        metallicity : numpy array
-            Gas metallicity (mass fraction) of the galaxy.
-        Z_sun : float, optional
-            Solar metallicity (default = 0.02).
-        beta : float, optional
-            Scaling exponent for redshift dependence.
-        Rv : float, optional
-            Total-to-selective extinction ratio for the CCM89 law (default = 3.1).
-
-        Returns
-        -------
-        lambda_tau_no_scatter : numpy array
-            Optical depth τ(λ) without the scattering correction.
-        """
-
-        A_Lambda_over_Av = self.ccm89_av_ratio(wavelength_microns, Rv=Rv)
-        wavelength_angstroms = (
-            np.array(wavelength_microns, ndmin=1) * 1e4
-        )  # Convert microns to angstroms
-        lambda_tau_no_scatter = np.zeros_like(wavelength_angstroms)
-
-        # Power law index s for metallicity dependence from Guiderdoni & Rocca-Volmerange (1987)
-        s = np.zeros_like(wavelength_angstroms)
-        mask1 = wavelength_angstroms <= 2000
-        s[mask1] = 1.35
-        mask2 = wavelength_angstroms > 2000
-        s[mask2] = 1.6
-
-        # Calculating the optical depth τ(λ) without scattering correction
-        lambda_tau_no_scatter = (
-            A_Lambda_over_Av[None, None, :]
-            * N_H_cm2[:, :, None]
-            / (2.1e21)
-            * (1.0 + redshift) ** beta
-            * (metallicity[:, :, None] / Z_sun) ** s[None, None, :]
-        )
-
-        return lambda_tau_no_scatter
-
-    def CSK1994_scatter(
-        self, wavelength_microns: np.ndarray, lambda_tau_no_scatter: np.ndarray
-    ) -> np.ndarray:
-        """
-        Compute the optical depth τ(λ) using the Calzetti, Seaton & Krügel (1994) model after dust scattering.
-
-        Parameters
-        ----------
-        wavelength_microns : float or array-like
-            Wavelength(s) in microns.
-        lambda_tau_no_scatter : numpy array
-            Optical depth τ(λ) without scattering correction, as computed by DG2000_optical_depth().
-
-        Returns
-        -------
-        lambda_tau_scatter : numpy array
-            Optical depth τ(λ) corrected for dust scattering.
-        """
-
-        wavelength_angstroms = (
-            np.array(wavelength_microns, ndmin=1) * 1e4
-        )  # Convert microns to angstroms
-        omega_Lambda = np.zeros_like(wavelength_angstroms)
-        h_Lambda = np.zeros_like(wavelength_angstroms)
-
-        # Calculating the albedo ω(λ) using the Calzetti et al. (1994) empirical fit
-        omega_Lambda = np.zeros_like(wavelength_angstroms)
-        mask1 = (wavelength_angstroms >= 1000) & (wavelength_angstroms <= 3460)
-        y = np.log10(wavelength_angstroms[mask1])
-        omega_Lambda[mask1] = 0.43 + 0.366 * (1.0 - np.exp(-((y - 3.0) ** 2) / 0.2))
-        mask2 = (wavelength_angstroms > 3460) & (wavelength_angstroms <= 7000)
-        y = np.log10(wavelength_angstroms[mask2])
-        omega_Lambda[mask2] = -0.48 * y + 2.41
-
-        # Table of omega_lambda from Natta & Panagia 1984 for wavelength between 0.7 to 4.48 microns
-
-        if np.any((wavelength_angstroms > 7000) & (wavelength_angstroms <= 44800)):
-            print(
-                'Warning: Wavelength out of range for CSK1994 scattering model (0.1 - 0.7 microns). Using Natta & Panagia 1984 table values for longer wavelengths.'
-            )
-            omega_table_wavelengths = np.array(
-                [0.7, 0.9, 1.25, 1.65, 2.2, 3.6, 4.48]
-            )  # microns
-
-            omega_table_values = np.array([0.56, 0.50, 0.37, 0.28, 0.22, 0.054, 0.0])
-
-            omega_interp = interp1d(
-                omega_table_wavelengths,
-                omega_table_values,
-                kind='cubic',
-                bounds_error=True,
-                fill_value=None,
-            )
-
-            mask4 = (wavelength_angstroms > 7000) & (wavelength_angstroms <= 44800)
-            omega_Lambda[mask4] = omega_interp(
-                wavelength_angstroms[mask4] / 1e4
-            )  # Convert back to microns for interpolation
-        elif np.any((wavelength_angstroms > 44800) | (wavelength_angstroms < 1000)):
-            print(
-                'Warning: No valid model for wavelength > 4.48 microns or < 0.1 microns in CSK1994 scattering model. Setting albedo to zero.'
-            )
-
-        # Calculating the weighting factor h(λ) that accounts for the anistropy in scattering
-        mask3 = (wavelength_angstroms >= 1200) & (wavelength_angstroms <= 7000)
-        y = np.log10(wavelength_angstroms[mask3])
-        h_Lambda[mask3] = 1.0 - 0.561 * np.exp(-(np.abs(y - 3.3112) ** 2.2) / 0.17)
-
-        if np.any((wavelength_angstroms > 7000) & (wavelength_angstroms <= 18000)):
-            print(
-                'Warning: Applying extrapolation for h(λ) beyond 0.7 microns. Bruzual et al 1988 has a table for g(λ) up to 1.8 microns, the functional form seems to hold approximately.'
-            )
-
-            mask5 = (wavelength_angstroms > 7000) & (wavelength_angstroms <= 18000)
-            y = np.log10(wavelength_angstroms[mask5])
-            h_Lambda[mask5] = 1.0 - 0.561 * np.exp(-(np.abs(y - 3.3112) ** 2.2) / 0.17)
-        elif np.any(wavelength_angstroms > 18000):
-            print(
-                'Warning: No valid model for h(λ) beyond 1.8 microns in CSK1994 scattering model. Setting h(λ) to one.'
-            )
-            mask6 = wavelength_angstroms > 18000
-            h_Lambda[mask6] = 1.0
-        elif np.any(wavelength_angstroms < 1200):
-            print(
-                'Warning: No valid model for h(λ) below 0.12 microns in CSK1994 scattering model. Setting h(λ) to zero.'
-            )
-
-        # Correcting the optical depth for scattering effects
-        correction_factor = h_Lambda * np.sqrt(1.0 - omega_Lambda) + (
-            1.0 - h_Lambda
-        ) * (1.0 - omega_Lambda)
-        lambda_tau_scatter = correction_factor[None, None, :] * lambda_tau_no_scatter
-
-        return lambda_tau_scatter
 
     def _compute_disk_rotation_matrices(self):
         """

--- a/kl_pipe/tng/data_vectors.py
+++ b/kl_pipe/tng/data_vectors.py
@@ -2074,14 +2074,6 @@ class TNGDataVectorGenerator:
             coords_2d, target_redshift=config.target_redshift
         )
 
-        print(
-            config.target_redshift,
-            np.min(coords_2d),
-            np.max(coords_2d),
-            np.min(coords_arcsec),
-            np.max(coords_arcsec),
-        )
-
         # Grid luminosities (sum, not weighted average)
         if config.use_cic_gridding:
             intensity = self._grid_particles_cic(

--- a/kl_pipe/tng/data_vectors.py
+++ b/kl_pipe/tng/data_vectors.py
@@ -118,7 +118,7 @@ TNG50_SNAPSHOT_99_REDSHIFT = 0.0
 # Default data directory. This is needed to load the auxillary data files for the BC03 models, which are used for converting between
 # luminosity and magnitude, and for distance conversions. The BC03 models are stored in a preprocessed HDF5 file that contains the
 # SED and absolute magnitude grids for different bands, as well as the age and metallicity grids.
-DEFAULT_DATA_DIR = Path(__file__).parent.parent.parent / "data" / "tng50"
+DEFAULT_DATA_DIR = Path(__file__).parent.parent.parent / 'data' / 'tng50'
 
 
 def convert_tng_to_arcsec(
@@ -177,7 +177,7 @@ def convert_tng_to_arcsec(
 
     else:
         raise ValueError(
-            "Target redshift must be provided and different from native redshift for angular size scaling if using the TNG50 sample at snapshot 99."
+            'Target redshift must be provided and different from native redshift for angular size scaling if using the TNG50 sample at snapshot 99.'
         )
 
     return coords_arcsec
@@ -431,10 +431,10 @@ def sph_project_2d(
         y_min = yi - 2 * hi
         y_max = yi + 2 * hi
 
-        ix_min = np.searchsorted(x_centers, x_min, side="left")
-        ix_max = np.searchsorted(x_centers, x_max, side="right")
-        iy_min = np.searchsorted(y_centers, y_min, side="left")
-        iy_max = np.searchsorted(y_centers, y_max, side="right")
+        ix_min = np.searchsorted(x_centers, x_min, side='left')
+        ix_max = np.searchsorted(x_centers, x_max, side='right')
+        iy_min = np.searchsorted(y_centers, y_min, side='left')
+        iy_max = np.searchsorted(y_centers, y_max, side='right')
 
         ix_min = max(ix_min, 0)
         ix_max = min(ix_max, nx)
@@ -509,7 +509,7 @@ class TNGRenderConfig:
     """
 
     image_pars: ImagePars
-    band: str = "r"
+    band: str = 'r'
     use_dusted: bool = True
     center_on_peak: bool = True
     use_native_orientation: bool = True
@@ -524,14 +524,14 @@ class TNGRenderConfig:
         """Validate configuration parameters."""
         # Validate shear parameters if custom orientation is used
         if not self.use_native_orientation and self.pars is not None:
-            g1 = self.pars.get("g1", 0.0)
-            g2 = self.pars.get("g2", 0.0)
+            g1 = self.pars.get('g1', 0.0)
+            g2 = self.pars.get('g2', 0.0)
             gamma = np.sqrt(g1**2 + g2**2)
             weak_lensing_limit = 1.0
             if gamma >= weak_lensing_limit:
                 raise ValueError(
-                    f"Shear too large: |g|={gamma:.3f} >= {weak_lensing_limit}. "
-                    f"Weak lensing requires |g| < {weak_lensing_limit}."
+                    f'Shear too large: |g|={gamma:.3f} >= {weak_lensing_limit}. '
+                    f'Weak lensing requires |g| < {weak_lensing_limit}.'
                 )
 
 
@@ -557,11 +557,13 @@ class TNGDataVectorGenerator:
         galaxy_data : dict
             Dictionary with keys 'gas', 'stellar', 'subhalo' containing
             the TNG data for one galaxy (from TNG50MockData.get_galaxy())
+        data_dir : Path, optional
+            Directory containing auxiliary data files (e.g., BC03 models).
         """
         self.galaxy_data = galaxy_data
-        self.stellar = galaxy_data.get("stellar")
-        self.gas = galaxy_data.get("gas")
-        self.subhalo = galaxy_data.get("subhalo")
+        self.stellar = galaxy_data.get('stellar')
+        self.gas = galaxy_data.get('gas')
+        self.subhalo = galaxy_data.get('subhalo')
 
         # Setting some constant parameters for the BC03 models. These are used for converting between luminosity and magnitude, and for distance conversions.
         self.L_sun = 3.826e33  # erg/s. The default value in galaxev
@@ -574,36 +576,36 @@ class TNGDataVectorGenerator:
 
         # AB absolute manitudes in different SDSS bands
         self.M_abs_sun = {
-            "u": 6.39,
-            "g": 5.11,
-            "r": 4.65,
-            "i": 4.53,
-            "z": 4.50,
+            'u': 6.39,
+            'g': 5.11,
+            'r': 4.65,
+            'i': 4.53,
+            'z': 4.50,
         }
 
         if self.stellar is None:
-            raise ValueError("Stellar data required for data vector generation")
+            raise ValueError('Stellar data required for data vector generation')
 
         if self.subhalo is None:
             raise ValueError(
-                "Subhalo data required for coordinate conversion and orientation"
+                'Subhalo data required for coordinate conversion and orientation'
             )
 
         if data_dir is None:
             data_dir = DEFAULT_DATA_DIR
-        output_path = data_dir / "SDSS_hr_stelib_stellar_photometrics.hdf5"
+        output_path = data_dir / 'SDSS_hr_stelib_stellar_photometrics.hdf5'
         filtdir = data_dir
         self.load_BC03_models(output_path, filtdir)
 
         # Store key properties
-        self.distance_mpc = float(self.subhalo["DistanceMpc"])
+        self.distance_mpc = float(self.subhalo['DistanceMpc'])
         self.native_redshift = TNG50_SNAPSHOT_99_REDSHIFT  # Snapshot 99
-        self.native_inclination_deg = float(self.subhalo["Inclination_star"])
-        self.native_pa_deg = float(self.subhalo["Position_Angle_star"])
+        self.native_inclination_deg = float(self.subhalo['Inclination_star'])
+        self.native_pa_deg = float(self.subhalo['Position_Angle_star'])
 
         # Store gas orientation for offset preservation
-        self.native_gas_inclination_deg = float(self.subhalo["Inclination_gas"])
-        self.native_gas_pa_deg = float(self.subhalo["Position_Angle_gas"])
+        self.native_gas_inclination_deg = float(self.subhalo['Inclination_gas'])
+        self.native_gas_pa_deg = float(self.subhalo['Position_Angle_gas'])
 
         # Compute 3D rotation matrices to transform from TNG simulation frame
         # to face-on disk frame. We compute SEPARATE matrices for stellar and gas
@@ -627,7 +629,7 @@ class TNGDataVectorGenerator:
         self.native_pa_rad = np.radians(self.native_pa_deg)
 
     def load_BC03_models(
-        self, output_path: Path, filtdir: Path, bands: set = {"g", "r", "i", "u", "z"}
+        self, output_path: Path, filtdir: Path, bands: set = {'g', 'r', 'i', 'u', 'z'}
     ):
         """Load BC03 SED and absolute magnitude grids from preprocessed HDF5 file. They are both interpolated in the same way (bilinear
         in log(age) and metallicity) to get the SED and absolute magnitude for each particle based on its age and metallicity. The SED grid
@@ -646,19 +648,19 @@ class TNGDataVectorGenerator:
         """
 
         self.absolute_mag_grid = {}
-        with h5py.File(output_path, "r") as f:
-            self.BC03_age_grid_logGr = f["LogAgeInGyr_bins"][:]  # log(age in Gyr) grid
-            self.BC03_metallicity_grid = f["Metallicity_bins"][:]
-            BC03_wave_ang = f["Wavelengths"][:]
-            BC03_SED_grid = f["SEDs"][:].astype(
+        with h5py.File(output_path, 'r') as f:
+            self.BC03_age_grid_logGr = f['LogAgeInGyr_bins'][:]  # log(age in Gyr) grid
+            self.BC03_metallicity_grid = f['Metallicity_bins'][:]
+            BC03_wave_ang = f['Wavelengths'][:]
+            BC03_SED_grid = f['SEDs'][:].astype(
                 np.float64
             )  # shape (N_metallicity, N_age, N_wave)
-            self.BC03_N_age = f["N_LogAgeInGyr"][()]
-            self.BC03_N_metallicity = f["N_Metallicity"][()]
+            self.BC03_N_age = f['N_LogAgeInGyr'][()]
+            self.BC03_N_metallicity = f['N_Metallicity'][()]
 
             for band in bands:
                 # Absolute magnitude grid for this band has shape (N_metallicity, N_age)
-                self.absolute_mag_grid[band] = f["Magnitude_" + band][:]
+                self.absolute_mag_grid[band] = f['Magnitude_' + band][:]
 
         self.wavelength_SED_within_filter = {}
         self.SED_within_filter_grid = {}
@@ -666,13 +668,13 @@ class TNGDataVectorGenerator:
         self.denominator_scalar = {}
         for band in bands:
             # Currently limited to the SDSS filters, but could be extended in the future.
-            filtname = filtdir / f"{band}_SDSS.res"
-            f = open(filtname, "r")
+            filtname = filtdir / f'{band}_SDSS.res'
+            f = open(filtname, 'r')
             filt_wave, filt_t = np.loadtxt(f, unpack=True)
             f.close()
 
             filt_spline = interp1d(
-                filt_wave, filt_t, kind="linear", bounds_error=False, fill_value=0.0
+                filt_wave, filt_t, kind='linear', bounds_error=False, fill_value=0.0
             )
 
             wmin_filt, wmax_filt = filt_wave[0], filt_wave[-1]
@@ -741,9 +743,9 @@ class TNGDataVectorGenerator:
         # Get stellar particles for this galaxy
         stellar_particles = self.stellar
 
-        initial_masses = stellar_particles["GFM_InitialMass"]
-        stellar_ages = stellar_particles["Stellar_age"]
-        metallicities_org = stellar_particles["GFM_Metallicity"]
+        initial_masses = stellar_particles['GFM_InitialMass']
+        stellar_ages = stellar_particles['Stellar_age']
+        metallicities_org = stellar_particles['GFM_Metallicity']
         ages = np.log10(
             stellar_ages
         )  # log10(Gyr). The time when the stars formed. This is consistent with the age grid from galaxev.
@@ -769,7 +771,7 @@ class TNGDataVectorGenerator:
 
         if len(n_out_of_bounds) > 0:
             print(
-                f"Warning: {len(n_out_of_bounds)} stellar particles out of {len(metallicities_org)} have metallicities out of the galaxev model bounds. They will be set to the nearest bound."
+                f'Warning: {len(n_out_of_bounds)} stellar particles out of {len(metallicities_org)} have metallicities out of the galaxev model bounds. They will be set to the nearest bound.'
             )
             metallicities = np.clip(
                 metallicities_org,
@@ -825,7 +827,7 @@ class TNGDataVectorGenerator:
                 if metallicity_SPH is None:
                     # Using the mass averaged metallcity if the pixel metallicity is not specified.
                     gas_metallicity = self.subhalo[
-                        "SubhaloGasMetallicity"
+                        'SubhaloGasMetallicity'
                     ] * np.ones_like(
                         N_H_cm2
                     )  # This is the mass-averaged metallicity of the gas in the galaxy, which is a single value for the whole galaxy. We will use this as a fallback if the
@@ -844,7 +846,7 @@ class TNGDataVectorGenerator:
                     wavelength_microns,
                     N_H_cm2,
                     gas_metallicity,
-                    self.subhalo["Redshift"],
+                    self.subhalo['Redshift'],
                 )
                 tau_lambda = self.CSK1994_scatter(wavelength_microns, tau_lambda_a)
             else:
@@ -861,10 +863,10 @@ class TNGDataVectorGenerator:
 
         # Pre-allocate the master 1D output arrays (These use negligible memory)
 
-        self.stellar["Absolute_Magnitude_rotate_" + band] = np.zeros(N_particles)
-        self.stellar["Raw_Luminosity_rotate_" + band] = np.zeros(N_particles)
-        self.stellar["Dusted_Luminosity_rotate_" + band] = np.zeros(N_particles)
-        self.stellar["Dusted_Absolute_Magnitude_rotate_" + band] = np.zeros(N_particles)
+        self.stellar['Absolute_Magnitude_rotate_' + band] = np.zeros(N_particles)
+        self.stellar['Raw_Luminosity_rotate_' + band] = np.zeros(N_particles)
+        self.stellar['Dusted_Luminosity_rotate_' + band] = np.zeros(N_particles)
+        self.stellar['Dusted_Absolute_Magnitude_rotate_' + band] = np.zeros(N_particles)
 
         tau_lambda_all[band] = dust_scatter(
             self.wavelength_SED_within_filter[band]
@@ -906,7 +908,7 @@ class TNGDataVectorGenerator:
             mass_chunk = initial_masses[start_idx:end_idx]
 
             print(
-                f"Processing particles {start_idx} to {end_idx} for galaxy ID {self.subhalo['SubhaloID']}"
+                f'Processing particles {start_idx} to {end_idx} for galaxy ID {self.subhalo["SubhaloID"]}'
             )
 
             lum_chunk = (
@@ -947,7 +949,7 @@ class TNGDataVectorGenerator:
                     # np.einsum instantly multiplies and sums along the wavelength axis (axis 1)
                     # This operates in C and allocates ZERO intermediate arrays!
                     dusted_integrals = np.einsum(
-                        "ij,ij->i", lum_chunk[valid_idx], dust_weights
+                        'ij,ij->i', lum_chunk[valid_idx], dust_weights
                     )
 
                     dusted_lum_nu[valid_idx] = (
@@ -956,7 +958,7 @@ class TNGDataVectorGenerator:
 
             # Convert L_nu (erg/s/Hz) to Absolute Magnitude using the AB magnitude system definition
             # Wrap the log10 calculations to silence the zero-flux warnings
-            with np.errstate(divide="ignore"):
+            with np.errstate(divide='ignore'):
                 raw_lum_AB_mag = (
                     -2.5
                     * np.log10(
@@ -983,14 +985,14 @@ class TNGDataVectorGenerator:
             # self.stellar_data[galaxy_id]["AB_apparent_magnitude_" + band][
             #     start_idx:end_idx
             # ] = app_mag
-            self.stellar["Absolute_Magnitude_rotate_" + band][
+            self.stellar['Absolute_Magnitude_rotate_' + band][
                 start_idx:end_idx
             ] = raw_lum_AB_mag
-            self.stellar["Raw_Luminosity_rotate_" + band][start_idx:end_idx] = raw_lum
-            self.stellar["Dusted_Luminosity_rotate_" + band][
+            self.stellar['Raw_Luminosity_rotate_' + band][start_idx:end_idx] = raw_lum
+            self.stellar['Dusted_Luminosity_rotate_' + band][
                 start_idx:end_idx
             ] = dusted_lum
-            self.stellar["Dusted_Absolute_Magnitude_rotate_" + band][
+            self.stellar['Dusted_Absolute_Magnitude_rotate_' + band][
                 start_idx:end_idx
             ] = dusted_lum_AB_mag
 
@@ -998,32 +1000,32 @@ class TNGDataVectorGenerator:
         # 4. GALAXY TOTALS
         # -----------------------------------------------------------------------------
 
-        total_raw = np.nansum(self.stellar["Raw_Luminosity_rotate_" + band])
-        total_dusted = np.nansum(self.stellar["Dusted_Luminosity_rotate_" + band])
+        total_raw = np.nansum(self.stellar['Raw_Luminosity_rotate_' + band])
+        total_dusted = np.nansum(self.stellar['Dusted_Luminosity_rotate_' + band])
 
-        self.subhalo["Raw_Luminosity_rotate_" + band] = total_raw
-        self.subhalo["Dusted_Luminosity_rotate_" + band] = total_dusted
+        self.subhalo['Raw_Luminosity_rotate_' + band] = total_raw
+        self.subhalo['Dusted_Luminosity_rotate_' + band] = total_dusted
 
-        self.subhalo["Absolute_Magnitude_rotate_" + band] = -2.5 * np.log10(
+        self.subhalo['Absolute_Magnitude_rotate_' + band] = -2.5 * np.log10(
             np.nansum(
-                10.0 ** (-0.4 * self.stellar["Absolute_Magnitude_rotate_" + band])
+                10.0 ** (-0.4 * self.stellar['Absolute_Magnitude_rotate_' + band])
             )
         )
 
-        self.subhalo["Dusted_Absolute_Magnitude_rotate_" + band] = -2.5 * np.log10(
+        self.subhalo['Dusted_Absolute_Magnitude_rotate_' + band] = -2.5 * np.log10(
             np.nansum(
                 10.0
-                ** (-0.4 * self.stellar["Dusted_Absolute_Magnitude_rotate_" + band])
+                ** (-0.4 * self.stellar['Dusted_Absolute_Magnitude_rotate_' + band])
             )
         )
 
-        print(f"Total raw luminosity in band {band}: {total_raw} erg/s")
-        print(f"Total dusted luminosity in band {band}: {total_dusted} erg/s")
+        print(f'Total raw luminosity in band {band}: {total_raw} erg/s')
+        print(f'Total dusted luminosity in band {band}: {total_dusted} erg/s')
         print(
-            f"Dusted absolute magnitude in band {band}: {self.subhalo['Dusted_Absolute_Magnitude_rotate_' + band]} mag"
+            f'Dusted absolute magnitude in band {band}: {self.subhalo["Dusted_Absolute_Magnitude_rotate_" + band]} mag'
         )
         print(
-            f"Raw absolute magnitude in band {band}: {self.subhalo['Absolute_Magnitude_rotate_' + band]} mag"
+            f'Raw absolute magnitude in band {band}: {self.subhalo["Absolute_Magnitude_rotate_" + band]} mag'
         )
 
     def hydrogen_column_density(
@@ -1066,7 +1068,7 @@ class TNGDataVectorGenerator:
 
         galaxy_data_single = self.subhalo
 
-        R_eff = galaxy_data_single["SubhaloHalfmassRadStars"]  # kpc
+        R_eff = galaxy_data_single['SubhaloHalfmassRadStars']  # kpc
         galaxy_pos = coords_rotate_2d_gas_center  # kpc
 
         # --- define grid boundaries ---
@@ -1079,21 +1081,21 @@ class TNGDataVectorGenerator:
             galaxy_pos[1] - grid_size, galaxy_pos[1] + grid_size, Ngrid + 1
         )
 
-        if gas_particles["Coordinates"] is None:
-            print(f"This galaxy has no gas particles.")
+        if gas_particles['Coordinates'] is None:
+            print(f'This galaxy has no gas particles.')
             N_H_cm2 = np.zeros((Ngrid, Ngrid))
             metallicity_sph = np.zeros((Ngrid, Ngrid))
         else:
             gas_coords = coords_rotate_2d_gas  # kpc
-            gas_masses = gas_particles["Masses"]  # Msun
-            GFM_Metals = gas_particles["GFM_Metals"][
+            gas_masses = gas_particles['Masses']  # Msun
+            GFM_Metals = gas_particles['GFM_Metals'][
                 :, 0
             ]  # total hydrogen mass fraction, hydrogen is the first element
             NeutroHydrogenAbundance = gas_particles[
-                "NeutralHydrogenAbundance"
+                'NeutralHydrogenAbundance'
             ]  # fraction of neutral hydrogen
             GFM_Metallicity = gas_particles[
-                "GFM_Metallicity"
+                'GFM_Metallicity'
             ]  # total metallicity, which is the mass fraction of all elements heavier than helium
             # --- project coordinates based on line-of-sight axis ---
 
@@ -1103,7 +1105,7 @@ class TNGDataVectorGenerator:
             gas_mass_sph = sph_project_2d(
                 gas_coords[:, 0],
                 gas_coords[:, 1],
-                gas_particles["SubfindHsml"],
+                gas_particles['SubfindHsml'],
                 weights,
                 x_edges,
                 y_edges,
@@ -1112,7 +1114,7 @@ class TNGDataVectorGenerator:
             metallicity_sph = sph_project_2d(
                 gas_coords[:, 0],
                 gas_coords[:, 1],
-                gas_particles["SubfindHsml"],
+                gas_particles['SubfindHsml'],
                 GFM_Metallicity * weights,
                 x_edges,
                 y_edges,
@@ -1144,7 +1146,7 @@ class TNGDataVectorGenerator:
             # We can check this and print a warning if it's not the case, which may indicate an issue with the SPH projection or the choice of grid parameters.
             if not np.isclose(total_input, total_projected, rtol=5e-2):
                 print(
-                    f"Warning: Mass conserved roughly. Input: {total_input}, Output: {total_projected}"
+                    f'Warning: Mass conserved roughly. Input: {total_input}, Output: {total_projected}'
                 )
 
             # --- compute per-pixel hydrogen mass in grams ---
@@ -1182,7 +1184,7 @@ class TNGDataVectorGenerator:
 
         if np.any((x < 0.3) | (x > 10)):
             print(
-                "Warning: Wavelength out of range for CCM89 extinction law (0.1 - 3.3 microns^-1)."
+                'Warning: Wavelength out of range for CCM89 extinction law (0.1 - 3.3 microns^-1).'
             )
 
         # --- Infrared (0.3 ≤ x < 1.1 μm⁻¹) ---
@@ -1351,7 +1353,7 @@ class TNGDataVectorGenerator:
 
         if np.any((wavelength_angstroms > 7000) & (wavelength_angstroms <= 44800)):
             print(
-                "Warning: Wavelength out of range for CSK1994 scattering model (0.1 - 0.7 microns). Using Natta & Panagia 1984 table values for longer wavelengths."
+                'Warning: Wavelength out of range for CSK1994 scattering model (0.1 - 0.7 microns). Using Natta & Panagia 1984 table values for longer wavelengths.'
             )
             omega_table_wavelengths = np.array(
                 [0.7, 0.9, 1.25, 1.65, 2.2, 3.6, 4.48]
@@ -1362,7 +1364,7 @@ class TNGDataVectorGenerator:
             omega_interp = interp1d(
                 omega_table_wavelengths,
                 omega_table_values,
-                kind="cubic",
+                kind='cubic',
                 bounds_error=True,
                 fill_value=None,
             )
@@ -1373,7 +1375,7 @@ class TNGDataVectorGenerator:
             )  # Convert back to microns for interpolation
         elif np.any((wavelength_angstroms > 44800) | (wavelength_angstroms < 1000)):
             print(
-                "Warning: No valid model for wavelength > 4.48 microns or < 0.1 microns in CSK1994 scattering model. Setting albedo to zero."
+                'Warning: No valid model for wavelength > 4.48 microns or < 0.1 microns in CSK1994 scattering model. Setting albedo to zero.'
             )
 
         # Calculating the weighting factor h(λ) that accounts for the anistropy in scattering
@@ -1383,7 +1385,7 @@ class TNGDataVectorGenerator:
 
         if np.any((wavelength_angstroms > 7000) & (wavelength_angstroms <= 18000)):
             print(
-                "Warning: Applying extrapolation for h(λ) beyond 0.7 microns. Bruzual et al 1988 has a table for g(λ) up to 1.8 microns, the functional form seems to hold approximately."
+                'Warning: Applying extrapolation for h(λ) beyond 0.7 microns. Bruzual et al 1988 has a table for g(λ) up to 1.8 microns, the functional form seems to hold approximately.'
             )
 
             mask5 = (wavelength_angstroms > 7000) & (wavelength_angstroms <= 18000)
@@ -1391,13 +1393,13 @@ class TNGDataVectorGenerator:
             h_Lambda[mask5] = 1.0 - 0.561 * np.exp(-(np.abs(y - 3.3112) ** 2.2) / 0.17)
         elif np.any(wavelength_angstroms > 18000):
             print(
-                "Warning: No valid model for h(λ) beyond 1.8 microns in CSK1994 scattering model. Setting h(λ) to one."
+                'Warning: No valid model for h(λ) beyond 1.8 microns in CSK1994 scattering model. Setting h(λ) to one.'
             )
             mask6 = wavelength_angstroms > 18000
             h_Lambda[mask6] = 1.0
         elif np.any(wavelength_angstroms < 1200):
             print(
-                "Warning: No valid model for h(λ) below 0.12 microns in CSK1994 scattering model. Setting h(λ) to zero."
+                'Warning: No valid model for h(λ) below 0.12 microns in CSK1994 scattering model. Setting h(λ) to zero.'
             )
 
         # Correcting the optical depth for scattering effects
@@ -1426,14 +1428,14 @@ class TNGDataVectorGenerator:
         # === Stellar rotation matrix from stellar particles ===
         # Use luminosity-weighted angular momentum for stellar particles
         # This is more physical than SubhaloSpin (which includes all particle types)
-        coords_stellar = self.stellar["Coordinates"]
-        vel_stellar = self.stellar["Velocities"]
+        coords_stellar = self.stellar['Coordinates']
+        vel_stellar = self.stellar['Velocities']
 
         # Use r-band luminosity as weights (or masses if not available)
-        if "Dusted_Luminosity_r" in self.stellar:
-            weights_stellar = self.stellar["Dusted_Luminosity_r"]
-        elif "Masses" in self.stellar:
-            weights_stellar = self.stellar["Masses"]
+        if 'Dusted_Luminosity_r' in self.stellar:
+            weights_stellar = self.stellar['Dusted_Luminosity_r']
+        elif 'Masses' in self.stellar:
+            weights_stellar = self.stellar['Masses']
         else:
             weights_stellar = np.ones(len(coords_stellar))
 
@@ -1461,10 +1463,10 @@ class TNGDataVectorGenerator:
         self._kinematic_inc_stellar_deg = np.rad2deg(np.arccos(np.abs(L_stellar[2])))
 
         # === Gas rotation matrix from particle angular momentum ===
-        if self.gas is not None and len(self.gas.get("Coordinates", [])) > 0:
-            coords_gas = self.gas["Coordinates"]
-            vel_gas = self.gas["Velocities"]
-            masses_gas = self.gas["Masses"]
+        if self.gas is not None and len(self.gas.get('Coordinates', [])) > 0:
+            coords_gas = self.gas['Coordinates']
+            vel_gas = self.gas['Velocities']
+            masses_gas = self.gas['Masses']
 
             # Center on mass-weighted centroid
             center_gas = np.average(coords_gas, axis=0, weights=masses_gas)
@@ -1552,25 +1554,25 @@ class TNGDataVectorGenerator:
         self, band: str, use_dusted: bool, rotate: bool = False
     ) -> str:
         """Get the appropriate luminosity key for the specified band."""
-        prefix = "Dusted_Luminosity" if use_dusted else "Raw_Luminosity"
+        prefix = 'Dusted_Luminosity' if use_dusted else 'Raw_Luminosity'
         if rotate and use_dusted:
-            prefix += "_rotate"
-        key = f"{prefix}_{band}"
+            prefix += '_rotate'
+        key = f'{prefix}_{band}'
         # Use the dusted luminosity after the rotation since the dust attenuation depends on the line-of-sight, so the luminosity values will change after the rotation.
         # The raw luminosity is unaffected by the rotation since it is intrinsic to the stellar population, so we can use the same raw luminosity values before and
         # after the rotation.
         # Validate key exists
         if key not in self.stellar:
-            available = [k for k in self.stellar.keys() if "Luminosity" in k]
+            available = [k for k in self.stellar.keys() if 'Luminosity' in k]
             raise KeyError(
                 f"Luminosity key '{key}' not found in stellar data. "
-                f"Available bands: {available}"
+                f'Available bands: {available}'
             )
 
         return key
 
     def _get_reference_center(
-        self, center_on_peak: bool, band: str = "r", use_dusted: bool = True
+        self, center_on_peak: bool, band: str = 'r', use_dusted: bool = True
     ) -> np.ndarray:
         """
         Get reference center for coordinate system (shared by intensity and velocity).
@@ -1596,15 +1598,15 @@ class TNGDataVectorGenerator:
             # Use stellar luminosity-weighted centroid as reference
             lum_key = self._get_luminosity_key(band, use_dusted)
             luminosities = self.stellar[lum_key]
-            stellar_coords = self.stellar["Coordinates"]
+            stellar_coords = self.stellar['Coordinates']
             center = np.average(stellar_coords, axis=0, weights=luminosities)
         else:
             # Use subhalo position
             center = np.array(
                 [
-                    self.subhalo["SubhaloPosX"],
-                    self.subhalo["SubhaloPosY"],
-                    self.subhalo["SubhaloPosZ"],
+                    self.subhalo['SubhaloPosX'],
+                    self.subhalo['SubhaloPosY'],
+                    self.subhalo['SubhaloPosZ'],
                 ]
             )
         return center
@@ -1628,7 +1630,7 @@ class TNGDataVectorGenerator:
         return coords - center
 
     def _undo_native_orientation(
-        self, coords: np.ndarray, velocities: np.ndarray, particle_type: str = "stellar"
+        self, coords: np.ndarray, velocities: np.ndarray, particle_type: str = 'stellar'
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         Transform from TNG's native obs frame to face-on disk plane.
@@ -1660,7 +1662,7 @@ class TNGDataVectorGenerator:
             Velocities in face-on disk plane, shape (n_particles, 3)
         """
         # Select the appropriate rotation matrix
-        if particle_type == "gas":
+        if particle_type == 'gas':
             R = self._R_to_disk_gas
         else:
             R = self._R_to_disk_stellar
@@ -1706,20 +1708,20 @@ class TNGDataVectorGenerator:
             3D coordinates in new obs frame (for diagnostics), shape (n_particles, 3)
         """
         # Extract parameters with defaults
-        cosi = pars.get("cosi", 1.0)
-        theta_int = pars.get("theta_int", 0.0)
-        x0 = pars.get("x0", 0.0)
-        y0 = pars.get("y0", 0.0)
-        g1 = pars.get("g1", 0.0)
-        g2 = pars.get("g2", 0.0)
+        cosi = pars.get('cosi', 1.0)
+        theta_int = pars.get('theta_int', 0.0)
+        x0 = pars.get('x0', 0.0)
+        y0 = pars.get('y0', 0.0)
+        g1 = pars.get('g1', 0.0)
+        g2 = pars.get('g2', 0.0)
 
         # Validate shear parameters
         gamma = np.sqrt(g1**2 + g2**2)
         weak_lensing_limit = 1.0
         if gamma >= weak_lensing_limit:
             raise ValueError(
-                f"Shear too large: |g|={gamma:.3f} >= {weak_lensing_limit}. "
-                f"Weak lensing requires |g| < {weak_lensing_limit}."
+                f'Shear too large: |g|={gamma:.3f} >= {weak_lensing_limit}. '
+                f'Weak lensing requires |g| < {weak_lensing_limit}.'
             )
 
         # ===================================================================
@@ -1810,7 +1812,7 @@ class TNGDataVectorGenerator:
         values: np.ndarray,
         weights: np.ndarray,
         image_pars: ImagePars,
-        mode: str = "weighted_average",
+        mode: str = 'weighted_average',
     ) -> np.ndarray:
         """
         Grid particles using Cloud-in-Cell (CIC) interpolation.
@@ -1838,11 +1840,11 @@ class TNGDataVectorGenerator:
             Gridded 2D map, shape determined by image_pars
         """
         # Get grid properties
-        X, Y = build_map_grid_from_image_pars(image_pars, unit="arcsec", centered=True)
+        X, Y = build_map_grid_from_image_pars(image_pars, unit='arcsec', centered=True)
         pixel_size = image_pars.pixel_scale
         Ny, Nx = (
             image_pars.shape
-            if image_pars.indexing == "ij"
+            if image_pars.indexing == 'ij'
             else (image_pars.shape[1], image_pars.shape[0])
         )
 
@@ -1853,7 +1855,7 @@ class TNGDataVectorGenerator:
 
         # Initialize arrays
         weighted_sum = np.zeros((Ny, Nx))
-        weight_sum = np.zeros((Ny, Nx)) if mode == "weighted_average" else None
+        weight_sum = np.zeros((Ny, Nx)) if mode == 'weighted_average' else None
 
         # Cloud-in-Cell: distribute to 4 nearest pixels
         x_floor = np.floor(x_pix).astype(int)
@@ -1897,18 +1899,18 @@ class TNGDataVectorGenerator:
                     values_valid * weights_valid * w_valid,
                 )
 
-                if mode == "weighted_average":
+                if mode == 'weighted_average':
                     np.add.at(weight_sum, (yi_valid, xi_valid), weights_valid * w_valid)
 
         # Compute result based on mode
-        if mode == "sum":
+        if mode == 'sum':
             result = weighted_sum
-        elif mode == "weighted_average":
+        elif mode == 'weighted_average':
             mask = weight_sum > 0
             result = np.zeros((Ny, Nx))
             result[mask] = weighted_sum[mask] / weight_sum[mask]
         else:
-            raise ValueError(f"Unknown mode: {mode}")
+            raise ValueError(f'Unknown mode: {mode}')
 
         return result
 
@@ -1918,7 +1920,7 @@ class TNGDataVectorGenerator:
         values: np.ndarray,
         weights: np.ndarray,
         image_pars: ImagePars,
-        mode: str = "weighted_average",
+        mode: str = 'weighted_average',
     ) -> np.ndarray:
         """
         Grid particles using nearest-grid-point (NGP) assignment.
@@ -1944,11 +1946,11 @@ class TNGDataVectorGenerator:
         np.ndarray
             Gridded 2D map, shape determined by image_pars
         """
-        X, Y = build_map_grid_from_image_pars(image_pars, unit="arcsec", centered=True)
+        X, Y = build_map_grid_from_image_pars(image_pars, unit='arcsec', centered=True)
         pixel_size = image_pars.pixel_scale
         Ny, Nx = (
             image_pars.shape
-            if image_pars.indexing == "ij"
+            if image_pars.indexing == 'ij'
             else (image_pars.shape[1], image_pars.shape[0])
         )
 
@@ -1965,9 +1967,9 @@ class TNGDataVectorGenerator:
             weights=values * weights,
         )
 
-        if mode == "sum":
+        if mode == 'sum':
             result = H_weighted
-        elif mode == "weighted_average":
+        elif mode == 'weighted_average':
             H_weights, _, _ = np.histogram2d(
                 y_pix, x_pix, bins=[Ny, Nx], range=[[0, Ny], [0, Nx]], weights=weights
             )
@@ -1976,7 +1978,7 @@ class TNGDataVectorGenerator:
             result = np.zeros((Ny, Nx))
             result[mask] = H_weighted[mask] / H_weights[mask]
         else:
-            raise ValueError(f"Unknown mode: {mode}")
+            raise ValueError(f'Unknown mode: {mode}')
 
         return result
 
@@ -2007,7 +2009,7 @@ class TNGDataVectorGenerator:
         """
 
         # Get coordinates
-        coords = self.stellar["Coordinates"].copy()
+        coords = self.stellar['Coordinates'].copy()
 
         # Get reference center (shared with velocity map for consistent FOV)
         center = self._get_reference_center(
@@ -2023,12 +2025,12 @@ class TNGDataVectorGenerator:
             # Transform stellar to specified orientation
             if config.pars is None:
                 raise ValueError(
-                    "pars must be provided when use_native_orientation=False"
+                    'pars must be provided when use_native_orientation=False'
                 )
 
             # Undo native orientation to get face-on stellar disk
             coords_disk, _ = self._undo_native_orientation(
-                coords_centered, np.zeros_like(coords_centered), particle_type="stellar"
+                coords_centered, np.zeros_like(coords_centered), particle_type='stellar'
             )
 
             # Apply new stellar orientation from pars
@@ -2040,7 +2042,7 @@ class TNGDataVectorGenerator:
                 # If using the dusted luminosity, we also need to apply the same rotation for the gas particles.
                 # This is because the dust attenuation depends on the line-of-sight, so the luminosity values will change after the rotation.
                 # We apply the same rotation to the gas particles to ensure that the dust attenuation is consistent with the new orientation of the stellar particles.
-                coords_gas = self.gas["Coordinates"].copy()
+                coords_gas = self.gas['Coordinates'].copy()
                 center_gas = self._get_reference_center(
                     config.center_on_peak, config.band, config.use_dusted
                 )
@@ -2048,7 +2050,7 @@ class TNGDataVectorGenerator:
                 coords_gas_disk, _ = self._undo_native_orientation(
                     coords_gas_centered,
                     np.zeros_like(coords_gas_centered),
-                    particle_type="gas",
+                    particle_type='gas',
                 )
                 coords_gas_2d, _, _ = self._apply_new_orientation(
                     coords_gas_disk, np.zeros_like(coords_gas_disk), config.pars
@@ -2081,7 +2083,7 @@ class TNGDataVectorGenerator:
                 luminosities_norm,
                 np.ones_like(luminosities_norm),
                 config.image_pars,
-                mode="sum",
+                mode='sum',
             )
         else:
             intensity = self._grid_particles_ngp(
@@ -2089,7 +2091,7 @@ class TNGDataVectorGenerator:
                 luminosities_norm,
                 np.ones_like(luminosities_norm),
                 config.image_pars,
-                mode="sum",
+                mode='sum',
             )
 
         # Rescale back to original units
@@ -2155,11 +2157,11 @@ class TNGDataVectorGenerator:
         """
         # Get gas particle data (truth for kinematics)
         if self.gas is None:
-            raise ValueError("Gas data required for velocity map generation")
+            raise ValueError('Gas data required for velocity map generation')
 
-        coords = self.gas["Coordinates"].copy()
-        velocities = self.gas["Velocities"].copy()
-        masses = self.gas["Masses"].copy()
+        coords = self.gas['Coordinates'].copy()
+        velocities = self.gas['Velocities'].copy()
+        masses = self.gas['Masses'].copy()
 
         # Subtract systemic velocity using mass-weighted mean of inner region
         # Use only inner particles to avoid bias from distant satellites/CGM
@@ -2196,7 +2198,7 @@ class TNGDataVectorGenerator:
             # Transform gas to the requested orientation
             if config.pars is None:
                 raise ValueError(
-                    "pars must be provided when use_native_orientation=False"
+                    'pars must be provided when use_native_orientation=False'
                 )
 
             # Choose which rotation matrix to use for gas particles:
@@ -2208,10 +2210,10 @@ class TNGDataVectorGenerator:
             #   User's (cosi, theta_int) refers to each component independently.
             if config.preserve_gas_stellar_offset:
                 # Use stellar rotation for gas -> preserves intrinsic misalignment
-                particle_type = "stellar"
+                particle_type = 'stellar'
             else:
                 # Use gas's own rotation -> aligns gas with user's requested orientation
-                particle_type = "gas"
+                particle_type = 'gas'
 
             # Undo native orientation to get face-on disk
             coords_disk, velocities_disk = self._undo_native_orientation(
@@ -2235,7 +2237,7 @@ class TNGDataVectorGenerator:
                 vel_los,
                 masses_norm,
                 config.image_pars,
-                mode="weighted_average",
+                mode='weighted_average',
             )
         else:
             velocity = self._grid_particles_ngp(
@@ -2243,7 +2245,7 @@ class TNGDataVectorGenerator:
                 vel_los,
                 masses_norm,
                 config.image_pars,
-                mode="weighted_average",
+                mode='weighted_average',
             )
 
         # Apply flux-weighted PSF convolution if requested
@@ -2254,8 +2256,8 @@ class TNGDataVectorGenerator:
                 import warnings
 
                 warnings.warn(
-                    "PSF set but no intensity_map provided to generate_velocity_map. "
-                    "Generating intensity internally (less efficient).",
+                    'PSF set but no intensity_map provided to generate_velocity_map. '
+                    'Generating intensity internally (less efficient).',
                     stacklevel=2,
                 )
                 intensity_map, _ = self.generate_intensity_map(config, snr=None)
@@ -2306,10 +2308,10 @@ class TNGDataVectorGenerator:
         from ..noise import add_noise
 
         # Get star formation rates (Msun/yr per particle)
-        sfr = self.gas["StarFormationRate"].copy()
+        sfr = self.gas['StarFormationRate'].copy()
 
         # Get coordinates
-        coords = self.gas["Coordinates"].copy()
+        coords = self.gas['Coordinates'].copy()
 
         # Get reference center (use stellar peak for consistency with intensity)
         center = self._get_reference_center(
@@ -2325,13 +2327,13 @@ class TNGDataVectorGenerator:
             # Transform gas to specified orientation
             if config.pars is None:
                 raise ValueError(
-                    "pars must be provided when use_native_orientation=False"
+                    'pars must be provided when use_native_orientation=False'
                 )
 
             # Undo native GAS orientation to get face-on gas disk
             # Uses the gas-specific angular momentum rotation matrix
             coords_disk, _ = self._undo_native_orientation(
-                coords_centered, np.zeros_like(coords_centered), particle_type="gas"
+                coords_centered, np.zeros_like(coords_centered), particle_type='gas'
             )
 
             # Apply requested orientation (same as velocity - uses gas angular momentum)
@@ -2347,11 +2349,11 @@ class TNGDataVectorGenerator:
         # Grid SFR (sum to get total SFR per pixel)
         if config.use_cic_gridding:
             sfr_map = self._grid_particles_cic(
-                coords_arcsec, sfr, np.ones_like(sfr), config.image_pars, mode="sum"
+                coords_arcsec, sfr, np.ones_like(sfr), config.image_pars, mode='sum'
             )
         else:
             sfr_map = self._grid_particles_ngp(
-                coords_arcsec, sfr, np.ones_like(sfr), config.image_pars, mode="sum"
+                coords_arcsec, sfr, np.ones_like(sfr), config.image_pars, mode='sum'
             )
 
         # Apply cosmological surface brightness dimming if requested

--- a/kl_pipe/tng/tng_dust.py
+++ b/kl_pipe/tng/tng_dust.py
@@ -1,0 +1,536 @@
+import numpy as np
+from numba import njit, prange
+from scipy.interpolate import interp1d
+
+"""This module contains the core numba-accelerated kernels for dust attenuation in the TNG pipeline. The main functions are:
+1. numba_bilinear_3d: A 3D bilinear interpolation kernel for getting SEDs from the grid based on particle metallicity and age.
+2. numba_bilinear_2d: A 2D bilinear interpolation kernel for getting absolute magnitudes from the grid based on particle metallicity and age.
+3. sph_project_2d: A 2D SPH projection kernel that takes particle positions, smoothing lengths, and weights (e.g., luminosities) and projects them onto a 2D pixel grid using a cubic spline kernel. 
+4. ccm89_av_ratio: A function to compute the extinction curve A(λ)/A(V) using the Cardelli, Clayton & Mathis (1989) extinction law.
+5. DG2000_optical_depth: A function to compute the optical depth τ(λ) using the Devriendt & Guiderdoni 2000 model, which depends on hydrogen column density, metallicity, and redshift.
+6. CSK1994_scatter: A function to compute the optical depth τ(λ) corrected for dust scattering effects using the Calzetti, Seaton & Krügel (1994) model, which includes wavelength-dependent albedo and anisotropy factors."""
+
+
+# -------------------------------------------------------------------------
+# 1. THE 3D SED KERNEL. Using numba to unroll the for loops and do the interpolation purely in the CPU cache for maximum speed.
+# -------------------------------------------------------------------------
+@njit(parallel=True, fastmath=True)
+def numba_bilinear_3d(
+    met_chunk: np.ndarray,
+    age_chunk: np.ndarray,
+    met_grid: np.ndarray,
+    age_grid: np.ndarray,
+    band_grid: np.ndarray,
+) -> np.ndarray:
+    """Bilinear interpolation in 2D (metallicity, age) for each particle to get SED for a specific band. Returns array of shape (N_particles, N_wave) with interpolated SEDs.
+
+    The input metallicity is the mass metallicity ratio from the TNG simulation. Not solar metallicity. The input age is in Gyr.
+    Parameters
+    ----------
+    met_chunk : np.ndarray
+        Metallicity values for each particle
+    age_chunk : np.ndarray
+        Age values for each particle
+    met_grid : np.ndarray
+        Grid of metallicity values
+    age_grid : np.ndarray
+        Grid of age values
+    band_grid : np.ndarray
+        Grid of SED values for a specific band, shape (N_met, N_age, N_wave)
+
+    Returns
+    -------
+    np.ndarray
+        Interpolated SEDs for each particle
+    """
+
+    N_particles = len(met_chunk)
+    N_wave = band_grid.shape[2]
+
+    # Pre-allocate the ONLY array that gets written to RAM
+    out_seds = np.empty((N_particles, N_wave), dtype=band_grid.dtype)
+
+    # prange splits the 100,000 particles across your CPU cores!
+    for i in prange(N_particles):
+        met = met_chunk[i]
+        age = age_chunk[i]
+
+        # Numba perfectly supports np.searchsorted
+        idx_met = np.searchsorted(met_grid, met) - 1
+        idx_age = np.searchsorted(age_grid, age) - 1
+
+        # Numba doesn't like np.clip on scalars, so we write explicit bounds
+        if idx_met < 0:
+            idx_met = 0
+        if idx_met > len(met_grid) - 2:
+            idx_met = len(met_grid) - 2
+        if idx_age < 0:
+            idx_age = 0
+        if idx_age > len(age_grid) - 2:
+            idx_age = len(age_grid) - 2
+
+        met1 = met_grid[idx_met]
+        met2 = met_grid[idx_met + 1]
+        age1 = age_grid[idx_age]
+        age2 = age_grid[idx_age + 1]
+
+        tx = (met - met1) / (met2 - met1)
+        ty = (age - age1) / (age2 - age1)
+
+        if tx < 0.0:
+            tx = 0.0
+        if tx > 1.0:
+            tx = 1.0
+        if ty < 0.0:
+            ty = 0.0
+        if ty > 1.0:
+            ty = 1.0
+
+        # Weights for the four corners of the grid cell
+        w11 = (1.0 - tx) * (1.0 - ty)
+        w21 = tx * (1.0 - ty)
+        w12 = (1.0 - tx) * ty
+        w22 = tx * ty
+
+        # THE MAGIC: Loop over wavelengths purely inside the CPU cache!
+        for j in range(N_wave):
+            out_seds[i, j] = (
+                band_grid[idx_met, idx_age, j] * w11
+                + band_grid[idx_met + 1, idx_age, j] * w21
+                + band_grid[idx_met, idx_age + 1, j] * w12
+                + band_grid[idx_met + 1, idx_age + 1, j] * w22
+            )
+
+    return out_seds
+
+
+# -------------------------------------------------------------------------
+# 2. THE 2D ABSOLUTE MAGNITUDE KERNEL. Similar to the 3D SED kernel but simpler since the grid is only 2D (metallicity, age) and the output is a single magnitude value
+# for each particle instead of a full SED. Still uses numba for speed.
+# -------------------------------------------------------------------------
+@njit(parallel=True, fastmath=True)
+def numba_bilinear_2d(
+    met_chunk: np.ndarray,
+    age_chunk: np.ndarray,
+    met_grid: np.ndarray,
+    age_grid: np.ndarray,
+    band_grid: np.ndarray,
+) -> np.ndarray:
+    """Bilinear interpolation in 2D (metallicity, age) for each particle to get absolute magnitude for a specific band. Returns array of shape (N_particles,)
+    with interpolated magnitudes.
+
+    The input metallicity is the mass metallicity ratio from the TNG simulation. Not solar metallicity. The input age is in Gyr.
+    Parameters
+    ----------
+    met_chunk : np.ndarray
+        Metallicity values for each particle
+    age_chunk : np.ndarray
+        Age values for each particle
+    met_grid : np.ndarray
+        Grid of metallicity values
+    age_grid : np.ndarray
+        Grid of age values
+    band_grid : np.ndarray
+        Grid of absolute magnitudes for a specific band, shape (N_met, N_age)
+
+    Returns
+    -------
+    np.ndarray
+        Interpolated magnitudes for each particle
+    """
+    N_particles = len(met_chunk)
+    out_mags = np.empty(N_particles, dtype=band_grid.dtype)
+
+    for i in prange(N_particles):
+        met = met_chunk[i]
+        age = age_chunk[i]
+
+        idx_met = np.searchsorted(met_grid, met) - 1
+        idx_age = np.searchsorted(age_grid, age) - 1
+
+        if idx_met < 0:
+            idx_met = 0
+        if idx_met > len(met_grid) - 2:
+            idx_met = len(met_grid) - 2
+        if idx_age < 0:
+            idx_age = 0
+        if idx_age > len(age_grid) - 2:
+            idx_age = len(age_grid) - 2
+
+        met1 = met_grid[idx_met]
+        met2 = met_grid[idx_met + 1]
+        age1 = age_grid[idx_age]
+        age2 = age_grid[idx_age + 1]
+
+        tx = (met - met1) / (met2 - met1)
+        ty = (age - age1) / (age2 - age1)
+
+        if tx < 0.0:
+            tx = 0.0
+        if tx > 1.0:
+            tx = 1.0
+        if ty < 0.0:
+            ty = 0.0
+        if ty > 1.0:
+            ty = 1.0
+
+        w11 = (1.0 - tx) * (1.0 - ty)
+        w21 = tx * (1.0 - ty)
+        w12 = (1.0 - tx) * ty
+        w22 = tx * ty
+
+        out_mags[i] = (
+            band_grid[idx_met, idx_age] * w11
+            + band_grid[idx_met + 1, idx_age] * w21
+            + band_grid[idx_met, idx_age + 1] * w12
+            + band_grid[idx_met + 1, idx_age + 1] * w22
+        )
+
+    return out_mags
+
+
+@njit(fastmath=True)
+def sph_project_2d(
+    x: np.ndarray,
+    y: np.ndarray,
+    h_tng: np.ndarray,
+    weights: np.ndarray,
+    x_edges: np.ndarray,
+    y_edges: np.ndarray,
+) -> np.ndarray:
+    """
+    2D SPH projection using cubic spline kernel. This is the core of the gridding process, where we take particle positions, smoothing lengths, and weights
+    (e.g., luminosities or masses) and project them onto a 2D pixel grid defined by x_edges and y_edges. Using numba to speed up the nested loops and avoid temporary arrays
+    for maximum performance.
+
+    Parameters:
+    x : np.ndarray
+        X coordinates of particles in kpc
+    y : np.ndarray
+        Y coordinates of particles in kpc
+    h_tng : np.ndarray
+        Smoothing lengths of particles in kpc (TNG defines Hsml as the full support radius, so we divide by 2 in the code to get the "h" used in the kernel)
+    weights : np.ndarray
+        Weights of particles (e.g., luminosities or masses)
+    x_edges : np.ndarray
+        Edges of the pixel grid in the X direction
+    y_edges : np.ndarray
+        Edges of the pixel grid in the Y direction
+
+    Returns
+    -------
+    np.ndarray
+        2D grid with projected values
+
+    """
+
+    nx = len(x_edges) - 1
+    ny = len(y_edges) - 1
+    grid = np.zeros((nx, ny))
+
+    dx = x_edges[1] - x_edges[0]
+    dy = y_edges[1] - y_edges[0]
+
+    x_centers = 0.5 * (x_edges[:-1] + x_edges[1:])
+    y_centers = 0.5 * (y_edges[:-1] + y_edges[1:])
+
+    for i in range(len(x)):
+        xi, yi = x[i], y[i]
+        # TNG defines Hsml as the full support radius. Our math expects half of that.
+        hi = h_tng[i] / 2.0
+        wi = weights[i]
+
+        if hi <= 0:
+            continue
+
+        # Handle Undersampling: If the particle is smaller than a pixel, dump it as a point mass
+        if hi < 0.5 * min(dx, dy):
+            ix = np.searchsorted(x_edges, xi) - 1
+            iy = np.searchsorted(y_edges, yi) - 1
+
+            if 0 <= ix < nx and 0 <= iy < ny:
+                # Convert mass to surface density
+                grid[ix, iy] += wi / (dx * dy)
+            continue
+
+        # Determine affected pixel range
+        x_min = xi - 2 * hi
+        x_max = xi + 2 * hi
+        y_min = yi - 2 * hi
+        y_max = yi + 2 * hi
+
+        ix_min = np.searchsorted(x_centers, x_min, side='left')
+        ix_max = np.searchsorted(x_centers, x_max, side='right')
+        iy_min = np.searchsorted(y_centers, y_min, side='left')
+        iy_max = np.searchsorted(y_centers, y_max, side='right')
+
+        ix_min = max(ix_min, 0)
+        ix_max = min(ix_max, nx)
+        iy_min = max(iy_min, 0)
+        iy_max = min(iy_max, ny)
+
+        # The 2D cubic spline normalization factor
+        norm = 10.0 / (7.0 * np.pi * hi**2)
+
+        # Pure scalar nested loops (Zero temporary arrays!)
+        for ix in range(ix_min, ix_max):
+            dx_pos = x_centers[ix] - xi
+
+            for iy in range(iy_min, iy_max):
+                dy_pos = y_centers[iy] - yi
+
+                r = np.sqrt(dx_pos**2 + dy_pos**2)
+                q = r / hi
+
+                if q < 1.0:
+                    w_val = norm * (1.0 - 1.5 * q**2 + 0.75 * q**3)
+                    grid[ix, iy] += wi * w_val
+                elif q < 2.0:
+                    w_val = norm * (0.25 * (2.0 - q) ** 3)
+                    grid[ix, iy] += wi * w_val
+
+    return grid
+
+
+def ccm89_av_ratio(wavelength_microns: np.ndarray, Rv: float = 3.1):
+    """
+    Compute A(λ)/A(V) using the Cardelli, Clayton & Mathis (1989) extinction law.
+
+    Parameters
+    ----------
+    wavelength_microns : numpy array
+        Wavelength(s) in microns.
+    Rv : float, optional
+        Total-to-selective extinction ratio (default = 3.1 for the diffuse ISM).
+
+    Returns
+    -------
+    A_lambda_over_Av : np.ndarray
+        Extinction curve A(λ)/A(V).
+    """
+    x = 1.0 / np.array(wavelength_microns, ndmin=1)  # inverse microns
+    a = np.zeros_like(x)
+    b = np.zeros_like(x)
+
+    if np.any((x < 0.3) | (x > 10)):
+        print(
+            'Warning: Wavelength out of range for CCM89 extinction law (0.1 - 3.3 microns^-1).'
+        )
+
+    # --- Infrared (0.3 ≤ x < 1.1 μm⁻¹) ---
+    mask_ir = (x >= 0.3) & (x < 1.1)
+    a[mask_ir] = 0.574 * x[mask_ir] ** 1.61
+    b[mask_ir] = -0.527 * x[mask_ir] ** 1.61
+
+    # --- Optical / NIR (1.1 ≤ x < 3.3 μm⁻¹) ---
+    mask_opt = (x >= 1.1) & (x < 3.3)
+    y = x[mask_opt] - 1.82
+    a[mask_opt] = (
+        1
+        + 0.17699 * y
+        - 0.50447 * y**2
+        - 0.02427 * y**3
+        + 0.72085 * y**4
+        + 0.01979 * y**5
+        - 0.77530 * y**6
+        + 0.32999 * y**7
+    )
+    b[mask_opt] = (
+        1.41338 * y
+        + 2.28305 * y**2
+        + 1.07233 * y**3
+        - 5.38434 * y**4
+        - 0.62251 * y**5
+        + 5.30260 * y**6
+        - 2.09002 * y**7
+    )
+
+    # --- Ultraviolet (3.3 ≤ x ≤ 8.0 μm⁻¹) ---
+    mask_uv = (x >= 3.3) & (x <= 8.0)
+    Fa = np.zeros_like(x[mask_uv])
+    Fb = np.zeros_like(x[mask_uv])
+    mask_uv_high = x[mask_uv] >= 5.9
+    if np.any(mask_uv_high):
+        xx = x[mask_uv][mask_uv_high] - 5.9
+        Fa[mask_uv_high] = -0.04473 * xx**2 - 0.009779 * xx**3
+        Fb[mask_uv_high] = 0.2130 * xx**2 + 0.1207 * xx**3
+
+    a[mask_uv] = (
+        1.752 - 0.316 * x[mask_uv] - 0.104 / ((x[mask_uv] - 4.67) ** 2 + 0.341) + Fa
+    )
+    b[mask_uv] = (
+        -3.090 + 1.825 * x[mask_uv] + 1.206 / ((x[mask_uv] - 4.62) ** 2 + 0.263) + Fb
+    )
+
+    # --- Far-UV (8.0 < x ≤ 10 μm⁻¹) ---
+    mask_fuv = (x > 8.0) & (x <= 10)
+    a[mask_fuv] = (
+        -1.073
+        - 0.628 * (x[mask_fuv] - 8.0)
+        + 0.137 * (x[mask_fuv] - 8.0) ** 2
+        - 0.070 * (x[mask_fuv] - 8.0) ** 3
+    )
+    b[mask_fuv] = (
+        13.670
+        + 4.257 * (x[mask_fuv] - 8.0)
+        - 0.420 * (x[mask_fuv] - 8.0) ** 2
+        + 0.374 * (x[mask_fuv] - 8.0) ** 3
+    )
+
+    # Final extinction law
+    A_lambda_over_Av = a + b / Rv
+
+    return A_lambda_over_Av if np.ndim(wavelength_microns) else A_lambda_over_Av.item()
+
+
+def DG2000_optical_depth(
+    wavelength_microns: np.ndarray,
+    N_H_cm2: np.ndarray,
+    metallicity: np.ndarray,
+    redshift: float,
+    Z_sun: float = 0.02,
+    beta: float = -0.5,
+    Rv: float = 3.1,
+) -> np.ndarray:
+    """
+    Compute the optical depth τ(λ) using the Devriendt & Guiderdoni 2000.
+
+    Parameters
+    ----------
+    wavelength_microns : numpy array
+        Wavelength(s) in microns.
+    N_H_cm2 : numpy array
+        Hydrogen column density in cm⁻².
+    metallicity : numpy array
+        Gas metallicity (mass fraction) of the galaxy.
+    Z_sun : float, optional
+        Solar metallicity (default = 0.02).
+    beta : float, optional
+        Scaling exponent for redshift dependence.
+    Rv : float, optional
+        Total-to-selective extinction ratio for the CCM89 law (default = 3.1).
+
+    Returns
+    -------
+    lambda_tau_no_scatter : numpy array
+        Optical depth τ(λ) without the scattering correction.
+    """
+
+    A_Lambda_over_Av = np.atleast_1d(ccm89_av_ratio(wavelength_microns, Rv=Rv))
+    wavelength_angstroms = (
+        np.array(wavelength_microns, ndmin=1) * 1e4
+    )  # Convert microns to angstroms
+    lambda_tau_no_scatter = np.zeros_like(wavelength_angstroms)
+
+    # Power law index s for metallicity dependence from Guiderdoni & Rocca-Volmerange (1987)
+    s = np.zeros_like(wavelength_angstroms)
+    mask1 = wavelength_angstroms <= 2000
+    s[mask1] = 1.35
+    mask2 = wavelength_angstroms > 2000
+    s[mask2] = 1.6
+
+    # Calculating the optical depth τ(λ) without scattering correction
+    lambda_tau_no_scatter = (
+        A_Lambda_over_Av[None, None, :]
+        * N_H_cm2[:, :, None]
+        / (2.1e21)
+        * (1.0 + redshift) ** beta
+        * (metallicity[:, :, None] / Z_sun) ** s[None, None, :]
+    )
+
+    return lambda_tau_no_scatter
+
+
+def CSK1994_scatter(
+    wavelength_microns: np.ndarray, lambda_tau_no_scatter: np.ndarray
+) -> np.ndarray:
+    """
+    Compute the optical depth τ(λ) using the Calzetti, Seaton & Krügel (1994) model after dust scattering.
+
+    Parameters
+    ----------
+    wavelength_microns : float or array-like
+        Wavelength(s) in microns.
+    lambda_tau_no_scatter : numpy array
+        Optical depth τ(λ) without scattering correction, as computed by DG2000_optical_depth().
+
+    Returns
+    -------
+    lambda_tau_scatter : numpy array
+        Optical depth τ(λ) corrected for dust scattering.
+    """
+
+    wavelength_angstroms = (
+        np.array(wavelength_microns, ndmin=1) * 1e4
+    )  # Convert microns to angstroms
+    omega_Lambda = np.zeros_like(wavelength_angstroms)
+    h_Lambda = np.zeros_like(wavelength_angstroms)
+
+    # Calculating the albedo ω(λ) using the Calzetti et al. (1994) empirical fit
+    omega_Lambda = np.zeros_like(wavelength_angstroms)
+    mask1 = (wavelength_angstroms >= 1000) & (wavelength_angstroms <= 3460)
+    y = np.log10(wavelength_angstroms[mask1])
+    omega_Lambda[mask1] = 0.43 + 0.366 * (1.0 - np.exp(-((y - 3.0) ** 2) / 0.2))
+    mask2 = (wavelength_angstroms > 3460) & (wavelength_angstroms <= 7000)
+    y = np.log10(wavelength_angstroms[mask2])
+    omega_Lambda[mask2] = -0.48 * y + 2.41
+
+    # Table of omega_lambda from Natta & Panagia 1984 for wavelength between 0.7 to 4.48 microns
+
+    if np.any((wavelength_angstroms > 7000) & (wavelength_angstroms <= 44800)):
+        print(
+            'Warning: Wavelength out of range for CSK1994 scattering model (0.1 - 0.7 microns). Using Natta & Panagia 1984 table values for longer wavelengths.'
+        )
+        omega_table_wavelengths = np.array(
+            [0.7, 0.9, 1.25, 1.65, 2.2, 3.6, 4.48]
+        )  # microns
+
+        omega_table_values = np.array([0.56, 0.50, 0.37, 0.28, 0.22, 0.054, 0.0])
+
+        omega_interp = interp1d(
+            omega_table_wavelengths,
+            omega_table_values,
+            kind='cubic',
+            bounds_error=True,
+        )
+
+        mask4 = (wavelength_angstroms > 7000) & (wavelength_angstroms <= 44800)
+        omega_Lambda[mask4] = omega_interp(
+            wavelength_angstroms[mask4] / 1e4
+        )  # Convert back to microns for interpolation
+    elif np.any((wavelength_angstroms > 44800) | (wavelength_angstroms < 1000)):
+        print(
+            'Warning: No valid model for wavelength > 4.48 microns or < 0.1 microns in CSK1994 scattering model. Setting albedo to zero.'
+        )
+
+    # Calculating the weighting factor h(λ) that accounts for the anistropy in scattering
+    mask3 = (wavelength_angstroms >= 1200) & (wavelength_angstroms <= 7000)
+    y = np.log10(wavelength_angstroms[mask3])
+    h_Lambda[mask3] = 1.0 - 0.561 * np.exp(-(np.abs(y - 3.3112) ** 2.2) / 0.17)
+
+    if np.any((wavelength_angstroms > 7000) & (wavelength_angstroms <= 18000)):
+        print(
+            'Warning: Applying extrapolation for h(λ) beyond 0.7 microns. Bruzual et al 1988 has a table for g(λ) up to 1.8 microns, the functional form seems to hold approximately.'
+        )
+
+        mask5 = (wavelength_angstroms > 7000) & (wavelength_angstroms <= 18000)
+        y = np.log10(wavelength_angstroms[mask5])
+        h_Lambda[mask5] = 1.0 - 0.561 * np.exp(-(np.abs(y - 3.3112) ** 2.2) / 0.17)
+    elif np.any(wavelength_angstroms > 18000):
+        print(
+            'Warning: No valid model for h(λ) beyond 1.8 microns in CSK1994 scattering model. Setting h(λ) to one.'
+        )
+        mask6 = wavelength_angstroms > 18000
+        h_Lambda[mask6] = 1.0
+    elif np.any(wavelength_angstroms < 1200):
+        print(
+            'Warning: No valid model for h(λ) below 0.12 microns in CSK1994 scattering model. Setting h(λ) to zero.'
+        )
+
+    # Correcting the optical depth for scattering effects
+    correction_factor = h_Lambda * np.sqrt(1.0 - omega_Lambda) + (1.0 - h_Lambda) * (
+        1.0 - omega_Lambda
+    )
+    lambda_tau_scatter = correction_factor[None, None, :] * lambda_tau_no_scatter
+
+    return lambda_tau_scatter

--- a/tests/test_psf_tng.py
+++ b/tests/test_psf_tng.py
@@ -11,7 +11,7 @@ import pytest
 import numpy as np
 import matplotlib
 
-matplotlib.use('Agg')
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from pathlib import Path
 
@@ -35,7 +35,8 @@ def tng_generator():
     from kl_pipe.tng import TNG50MockData, TNGDataVectorGenerator
 
     tng_data = TNG50MockData()
-    galaxy = tng_data.get_galaxy(subhalo_id=8)
+    # galaxy = tng_data.get_galaxy(subhalo_id=8)
+    galaxy = tng_data.get_galaxy(index=0)
     return TNGDataVectorGenerator(galaxy)
 
 
@@ -44,7 +45,7 @@ def tng_config():
     """Render config for TNG tests."""
     from kl_pipe.tng.data_vectors import TNGRenderConfig
 
-    image_pars = ImagePars(shape=(64, 64), pixel_scale=0.11, indexing='xy')
+    image_pars = ImagePars(shape=(64, 64), pixel_scale=0.11, indexing="xy")
     return TNGRenderConfig(
         image_pars=image_pars,
         target_redshift=0.5,
@@ -92,22 +93,22 @@ def test_tng_intensity_with_psf(tng_generator, tng_config, tng_psf, output_dir):
     # diagnostic plot
     fig, axes = plt.subplots(1, 3, figsize=(15, 5))
 
-    im0 = axes[0].imshow(intensity_no_psf, origin='lower', cmap='viridis')
-    axes[0].set_title('No PSF')
+    im0 = axes[0].imshow(intensity_no_psf, origin="lower", cmap="viridis")
+    axes[0].set_title("No PSF")
     plt.colorbar(im0, ax=axes[0])
 
-    im1 = axes[1].imshow(intensity_psf, origin='lower', cmap='viridis')
-    axes[1].set_title('With PSF')
+    im1 = axes[1].imshow(intensity_psf, origin="lower", cmap="viridis")
+    axes[1].set_title("With PSF")
     plt.colorbar(im1, ax=axes[1])
 
     diff = intensity_psf - intensity_no_psf
-    im2 = axes[2].imshow(diff, origin='lower', cmap='RdBu_r')
-    axes[2].set_title('Difference')
+    im2 = axes[2].imshow(diff, origin="lower", cmap="RdBu_r")
+    axes[2].set_title("Difference")
     plt.colorbar(im2, ax=axes[2])
 
-    fig.suptitle(f'TNG SubhaloID 8 Intensity (flux diff: {rel_flux_diff:.2e})')
+    fig.suptitle(f"TNG SubhaloID 8 Intensity (flux diff: {rel_flux_diff:.2e})")
     plt.tight_layout()
-    plt.savefig(output_dir / 'tng_intensity_psf_comparison.png', dpi=150)
+    plt.savefig(output_dir / "tng_intensity_psf_comparison.png", dpi=150)
     plt.close()
 
 
@@ -143,25 +144,25 @@ def test_tng_velocity_with_psf(tng_generator, tng_config, tng_psf, output_dir):
     vmax = max(np.percentile(velocity_no_psf, 98), np.percentile(velocity_psf, 98))
 
     im0 = axes[0].imshow(
-        velocity_no_psf, origin='lower', cmap='RdBu_r', vmin=vmin, vmax=vmax
+        velocity_no_psf, origin="lower", cmap="RdBu_r", vmin=vmin, vmax=vmax
     )
-    axes[0].set_title(f'No PSF (range={range_no_psf:.0f})')
+    axes[0].set_title(f"No PSF (range={range_no_psf:.0f})")
     plt.colorbar(im0, ax=axes[0])
 
     im1 = axes[1].imshow(
-        velocity_psf, origin='lower', cmap='RdBu_r', vmin=vmin, vmax=vmax
+        velocity_psf, origin="lower", cmap="RdBu_r", vmin=vmin, vmax=vmax
     )
-    axes[1].set_title(f'With PSF (range={range_psf:.0f})')
+    axes[1].set_title(f"With PSF (range={range_psf:.0f})")
     plt.colorbar(im1, ax=axes[1])
 
     diff = velocity_psf - velocity_no_psf
-    im2 = axes[2].imshow(diff, origin='lower', cmap='RdBu_r')
-    axes[2].set_title('Difference')
+    im2 = axes[2].imshow(diff, origin="lower", cmap="RdBu_r")
+    axes[2].set_title("Difference")
     plt.colorbar(im2, ax=axes[2])
 
-    fig.suptitle('TNG SubhaloID 8 Velocity')
+    fig.suptitle("TNG SubhaloID 8 Velocity")
     plt.tight_layout()
-    plt.savefig(output_dir / 'tng_velocity_psf_comparison.png', dpi=150)
+    plt.savefig(output_dir / "tng_velocity_psf_comparison.png", dpi=150)
     plt.close()
 
 

--- a/tests/test_psf_tng.py
+++ b/tests/test_psf_tng.py
@@ -11,7 +11,7 @@ import pytest
 import numpy as np
 import matplotlib
 
-matplotlib.use("Agg")
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from pathlib import Path
 
@@ -20,16 +20,16 @@ import galsim as gs
 from kl_pipe.parameters import ImagePars
 from kl_pipe.utils import get_test_dir
 
-OUTPUT_DIR = get_test_dir() / "out" / "psf_tng"
+OUTPUT_DIR = get_test_dir() / 'out' / 'psf_tng'
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def output_dir():
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     return OUTPUT_DIR
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def tng_generator():
     """Load TNG generator for SubhaloID 8."""
     from kl_pipe.tng import TNG50MockData, TNGDataVectorGenerator
@@ -40,12 +40,12 @@ def tng_generator():
     return TNGDataVectorGenerator(galaxy)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def tng_config():
     """Render config for TNG tests."""
     from kl_pipe.tng.data_vectors import TNGRenderConfig
 
-    image_pars = ImagePars(shape=(64, 64), pixel_scale=0.11, indexing="xy")
+    image_pars = ImagePars(shape=(64, 64), pixel_scale=0.11, indexing='xy')
     return TNGRenderConfig(
         image_pars=image_pars,
         target_redshift=0.5,
@@ -53,7 +53,7 @@ def tng_config():
     )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def tng_psf():
     return gs.Gaussian(fwhm=0.625)
 
@@ -83,32 +83,32 @@ def test_tng_intensity_with_psf(tng_generator, tng_config, tng_psf, output_dir):
     flux_no_psf = np.sum(intensity_no_psf)
     flux_psf = np.sum(intensity_psf)
     rel_flux_diff = abs(flux_psf - flux_no_psf) / abs(flux_no_psf)
-    assert rel_flux_diff < 0.01, f"Flux not conserved: {rel_flux_diff:.2%} difference"
+    assert rel_flux_diff < 0.01, f'Flux not conserved: {rel_flux_diff:.2%} difference'
 
     # PSF version should have lower peak (smoother)
     assert np.max(intensity_psf) < np.max(
         intensity_no_psf
-    ), "PSF-convolved intensity should have lower peak"
+    ), 'PSF-convolved intensity should have lower peak'
 
     # diagnostic plot
     fig, axes = plt.subplots(1, 3, figsize=(15, 5))
 
-    im0 = axes[0].imshow(intensity_no_psf, origin="lower", cmap="viridis")
-    axes[0].set_title("No PSF")
+    im0 = axes[0].imshow(intensity_no_psf, origin='lower', cmap='viridis')
+    axes[0].set_title('No PSF')
     plt.colorbar(im0, ax=axes[0])
 
-    im1 = axes[1].imshow(intensity_psf, origin="lower", cmap="viridis")
-    axes[1].set_title("With PSF")
+    im1 = axes[1].imshow(intensity_psf, origin='lower', cmap='viridis')
+    axes[1].set_title('With PSF')
     plt.colorbar(im1, ax=axes[1])
 
     diff = intensity_psf - intensity_no_psf
-    im2 = axes[2].imshow(diff, origin="lower", cmap="RdBu_r")
-    axes[2].set_title("Difference")
+    im2 = axes[2].imshow(diff, origin='lower', cmap='RdBu_r')
+    axes[2].set_title('Difference')
     plt.colorbar(im2, ax=axes[2])
 
-    fig.suptitle(f"TNG SubhaloID 8 Intensity (flux diff: {rel_flux_diff:.2e})")
+    fig.suptitle(f'TNG SubhaloID 8 Intensity (flux diff: {rel_flux_diff:.2e})')
     plt.tight_layout()
-    plt.savefig(output_dir / "tng_intensity_psf_comparison.png", dpi=150)
+    plt.savefig(output_dir / 'tng_intensity_psf_comparison.png', dpi=150)
     plt.close()
 
 
@@ -135,7 +135,7 @@ def test_tng_velocity_with_psf(tng_generator, tng_config, tng_psf, output_dir):
     range_psf = np.ptp(velocity_psf)
     assert (
         range_psf < range_no_psf
-    ), f"PSF should reduce velocity range: {range_no_psf:.1f} -> {range_psf:.1f}"
+    ), f'PSF should reduce velocity range: {range_no_psf:.1f} -> {range_psf:.1f}'
 
     # diagnostic plot
     fig, axes = plt.subplots(1, 3, figsize=(15, 5))
@@ -144,27 +144,27 @@ def test_tng_velocity_with_psf(tng_generator, tng_config, tng_psf, output_dir):
     vmax = max(np.percentile(velocity_no_psf, 98), np.percentile(velocity_psf, 98))
 
     im0 = axes[0].imshow(
-        velocity_no_psf, origin="lower", cmap="RdBu_r", vmin=vmin, vmax=vmax
+        velocity_no_psf, origin='lower', cmap='RdBu_r', vmin=vmin, vmax=vmax
     )
-    axes[0].set_title(f"No PSF (range={range_no_psf:.0f})")
+    axes[0].set_title(f'No PSF (range={range_no_psf:.0f})')
     plt.colorbar(im0, ax=axes[0])
 
     im1 = axes[1].imshow(
-        velocity_psf, origin="lower", cmap="RdBu_r", vmin=vmin, vmax=vmax
+        velocity_psf, origin='lower', cmap='RdBu_r', vmin=vmin, vmax=vmax
     )
-    axes[1].set_title(f"With PSF (range={range_psf:.0f})")
+    axes[1].set_title(f'With PSF (range={range_psf:.0f})')
     plt.colorbar(im1, ax=axes[1])
 
     diff = velocity_psf - velocity_no_psf
-    im2 = axes[2].imshow(diff, origin="lower", cmap="RdBu_r")
-    axes[2].set_title("Difference")
+    im2 = axes[2].imshow(diff, origin='lower', cmap='RdBu_r')
+    axes[2].set_title('Difference')
     plt.colorbar(im2, ax=axes[2])
 
-    fig.suptitle("TNG SubhaloID 8 Velocity")
+    fig.suptitle('TNG SubhaloID 8 Velocity')
     plt.tight_layout()
-    plt.savefig(output_dir / "tng_velocity_psf_comparison.png", dpi=150)
+    plt.savefig(output_dir / 'tng_velocity_psf_comparison.png', dpi=150)
     plt.close()
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v", "-s", "-m", "tng50"])
+if __name__ == '__main__':
+    pytest.main([__file__, '-v', '-s', '-m', 'tng50'])

--- a/tests/test_tng_data_vectors.py
+++ b/tests/test_tng_data_vectors.py
@@ -894,6 +894,53 @@ class TestInclinationSymmetry:
         print(f"✓ Face-on intensity median_rel_diff = {int_median_rel_diff:.3f}")
 
 
+class TestDustAttenuation:
+    """Test dust attenuation effects."""
+
+    def test_dust_attenuation_reduces_flux(self, test_galaxy, image_pars_test):
+        """Dust attenuation should reduce total flux."""
+        gen = TNGDataVectorGenerator(test_galaxy)
+
+        config_dusted = TNGRenderConfig(
+            target_redshift=0.6, image_pars=image_pars_test, band="r", use_dusted=True
+        )
+        intensity_dusted, _ = gen.generate_intensity_map(config_dusted)
+
+        config_raw = TNGRenderConfig(
+            target_redshift=0.6, image_pars=image_pars_test, band="r", use_dusted=False
+        )
+        intensity_raw, _ = gen.generate_intensity_map(config_raw)
+
+        assert (
+            intensity_raw.sum() > intensity_dusted.sum()
+        ), "Dust should attenuate flux"
+
+    def test_dust_attenuation_model(self, test_galaxy):
+        gen = TNGDataVectorGenerator(test_galaxy)
+
+        # Compute the dust attenuation in the native coordinates for this galaxy and compared to the result stored in the TNG data.
+        # The two should give consistent results since they have the same dust attenuation model.
+
+        # Assuming using catalogues that fixed the line-of-sight to be along the z-axis.
+        coords_stellar_2d = gen.stellar["Coordinates"][:, :2]  # x,y positions
+        coords_gas_2d = gen.gas["Coordinates"][:, :2]
+        coords_galaxy_center_2d = gen.subhalo["SubhaloPos"][:2]  # x,y of galaxy center
+
+        # Using the native orientation to compute the dust attenuation and compare to the TNG data.
+        gen._estimate_magnitude_luminosity(
+            coords_stellar_2d, coords_gas_2d, coords_galaxy_center_2d, band="r"
+        )
+
+        assert np.allclose(
+            gen.stellar["Dusted_Luminosity_rotate_r"],
+            gen.stellar["Dusted_Luminosity_r"],
+        ), "Stellar luminosity after dust attenuation correction should match TNG data"
+        assert np.allclose(
+            gen.stellar["Dusted_Absolute_Magnitude_rotate_r"],
+            gen.stellar["Dusted_Absolute_Magnitude_r"],
+        ), "Stellar absolute magnitude after dust attenuation correction should match TNG data"
+
+
 @pytest.mark.tng_diagnostics
 class TestDiagnosticPlots:
     """Generate diagnostic plots for visual validation of TNG rendering.

--- a/tests/test_tng_data_vectors.py
+++ b/tests/test_tng_data_vectors.py
@@ -32,7 +32,7 @@ def test_galaxy(tng_data):
 @pytest.fixture
 def image_pars_test():
     """Standard test image parameters."""
-    return ImagePars(shape=(64, 64), pixel_scale=0.1, indexing='ij')
+    return ImagePars(shape=(64, 64), pixel_scale=0.1, indexing="ij")
 
 
 @pytest.fixture
@@ -50,7 +50,7 @@ class TestBasicRendering:
         config = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band='r',
+            band="r",
             use_native_orientation=True,
             use_cic_gridding=True,
         )
@@ -69,7 +69,7 @@ class TestBasicRendering:
         config = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band='r',
+            band="r",
             use_native_orientation=True,
             use_cic_gridding=True,
         )
@@ -90,17 +90,17 @@ class TestOrientation:
         """Test rendering at face-on orientation."""
         gen = TNGDataVectorGenerator(test_galaxy)
         pars = {
-            'theta_int': 0.0,
-            'cosi': 1.0,
-            'x0': 0.0,
-            'y0': 0.0,
-            'g1': 0.0,
-            'g2': 0.0,
+            "theta_int": 0.0,
+            "cosi": 1.0,
+            "x0": 0.0,
+            "y0": 0.0,
+            "g1": 0.0,
+            "g2": 0.0,
         }
         config = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band='r',
+            band="r",
             use_native_orientation=False,
             pars=pars,
             use_cic_gridding=True,
@@ -117,17 +117,17 @@ class TestOrientation:
         """Test rendering at edge-on orientation."""
         gen = TNGDataVectorGenerator(test_galaxy)
         pars = {
-            'theta_int': 0.0,
-            'cosi': 0.1,
-            'x0': 0.0,
-            'y0': 0.0,
-            'g1': 0.0,
-            'g2': 0.0,
+            "theta_int": 0.0,
+            "cosi": 0.1,
+            "x0": 0.0,
+            "y0": 0.0,
+            "g1": 0.0,
+            "g2": 0.0,
         }
         config = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band='r',
+            band="r",
             use_native_orientation=False,
             pars=pars,
             use_cic_gridding=True,
@@ -145,17 +145,17 @@ class TestOrientation:
 
         # Face-on
         pars_face = {
-            'theta_int': 0.0,
-            'cosi': 1.0,
-            'x0': 0.0,
-            'y0': 0.0,
-            'g1': 0.0,
-            'g2': 0.0,
+            "theta_int": 0.0,
+            "cosi": 1.0,
+            "x0": 0.0,
+            "y0": 0.0,
+            "g1": 0.0,
+            "g2": 0.0,
         }
         config_face = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band='r',
+            band="r",
             use_native_orientation=False,
             pars=pars_face,
         )
@@ -164,17 +164,17 @@ class TestOrientation:
 
         # Edge-on
         pars_edge = {
-            'theta_int': 0.0,
-            'cosi': 0.1,
-            'x0': 0.0,
-            'y0': 0.0,
-            'g1': 0.0,
-            'g2': 0.0,
+            "theta_int": 0.0,
+            "cosi": 0.1,
+            "x0": 0.0,
+            "y0": 0.0,
+            "g1": 0.0,
+            "g2": 0.0,
         }
         config_edge = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band='r',
+            band="r",
             use_native_orientation=False,
             pars=pars_edge,
         )
@@ -194,17 +194,17 @@ class TestOrientation:
 
         # PA = 0
         pars_0 = {
-            'theta_int': 0.0,
-            'cosi': 0.7,
-            'x0': 0.0,
-            'y0': 0.0,
-            'g1': 0.0,
-            'g2': 0.0,
+            "theta_int": 0.0,
+            "cosi": 0.7,
+            "x0": 0.0,
+            "y0": 0.0,
+            "g1": 0.0,
+            "g2": 0.0,
         }
         config_0 = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band='r',
+            band="r",
             use_native_orientation=False,
             pars=pars_0,
         )
@@ -212,17 +212,17 @@ class TestOrientation:
 
         # PA = 90 degrees
         pars_90 = {
-            'theta_int': np.pi / 2,
-            'cosi': 0.7,
-            'x0': 0.0,
-            'y0': 0.0,
-            'g1': 0.0,
-            'g2': 0.0,
+            "theta_int": np.pi / 2,
+            "cosi": 0.7,
+            "x0": 0.0,
+            "y0": 0.0,
+            "g1": 0.0,
+            "g2": 0.0,
         }
         config_90 = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band='r',
+            band="r",
             use_native_orientation=False,
             pars=pars_90,
         )
@@ -241,7 +241,7 @@ class TestGridding:
         config = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band='r',
+            band="r",
             use_cic_gridding=True,
         )
 
@@ -257,7 +257,7 @@ class TestGridding:
         config = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band='r',
+            band="r",
             use_cic_gridding=False,
         )
 
@@ -274,7 +274,7 @@ class TestGridding:
         config_cic = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band='r',
+            band="r",
             use_cic_gridding=True,
         )
         intensity_cic, _ = gen.generate_intensity_map(config_cic)
@@ -282,7 +282,7 @@ class TestGridding:
         config_ngp = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band='r',
+            band="r",
             use_cic_gridding=False,
         )
         intensity_ngp, _ = gen.generate_intensity_map(config_ngp)
@@ -301,7 +301,7 @@ class TestGridding:
         config_cic = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band='r',
+            band="r",
             use_cic_gridding=True,
         )
         intensity_cic, _ = gen.generate_intensity_map(config_cic)
@@ -309,7 +309,7 @@ class TestGridding:
         config_ngp = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band='r',
+            band="r",
             use_cic_gridding=False,
         )
         intensity_ngp, _ = gen.generate_intensity_map(config_ngp)
@@ -330,7 +330,7 @@ class TestNoise:
         """Adding noise should increase variance."""
         gen = TNGDataVectorGenerator(test_galaxy)
         config = TNGRenderConfig(
-            target_redshift=0.6, image_pars=image_pars_test, band='r'
+            target_redshift=0.6, image_pars=image_pars_test, band="r"
         )
 
         intensity_clean, var_clean = gen.generate_intensity_map(config, snr=None)
@@ -344,7 +344,7 @@ class TestNoise:
         """Same seed should produce same noise."""
         gen = TNGDataVectorGenerator(test_galaxy)
         config = TNGRenderConfig(
-            target_redshift=0.6, image_pars=image_pars_test, band='r'
+            target_redshift=0.6, image_pars=image_pars_test, band="r"
         )
 
         intensity_1, var_1 = gen.generate_intensity_map(config, snr=50, seed=42)
@@ -359,7 +359,7 @@ class TestNoise:
         """Different seeds should produce different noise."""
         gen = TNGDataVectorGenerator(test_galaxy)
         config = TNGRenderConfig(
-            target_redshift=0.6, image_pars=image_pars_test, band='r'
+            target_redshift=0.6, image_pars=image_pars_test, band="r"
         )
 
         intensity_1, _ = gen.generate_intensity_map(config, snr=50, seed=42)
@@ -375,7 +375,7 @@ class TestParticleTypes:
         """Intensity should use stellar particles."""
         gen = TNGDataVectorGenerator(test_galaxy)
         config = TNGRenderConfig(
-            target_redshift=0.6, image_pars=image_pars_test, band='r'
+            target_redshift=0.6, image_pars=image_pars_test, band="r"
         )
 
         # Should work even without gas data
@@ -391,7 +391,7 @@ class TestParticleTypes:
             pytest.skip("Galaxy missing gas data")
 
         config = TNGRenderConfig(
-            target_redshift=0.6, image_pars=image_pars_test, band='r'
+            target_redshift=0.6, image_pars=image_pars_test, band="r"
         )
         velocity, _ = gen.generate_velocity_map(config)
 
@@ -402,7 +402,7 @@ class TestParticleTypes:
 class TestPhotometricBands:
     """Test different photometric bands."""
 
-    @pytest.mark.parametrize("band", ['g', 'r', 'i', 'u', 'z'])
+    @pytest.mark.parametrize("band", ["g", "r", "i", "u", "z"])
     def test_all_bands_work(self, test_galaxy, image_pars_test, band):
         """All SDSS bands should render successfully."""
         gen = TNGDataVectorGenerator(test_galaxy)
@@ -418,12 +418,12 @@ class TestPhotometricBands:
         gen = TNGDataVectorGenerator(test_galaxy)
 
         config_dusted = TNGRenderConfig(
-            target_redshift=0.6, image_pars=image_pars_test, band='r', use_dusted=True
+            target_redshift=0.6, image_pars=image_pars_test, band="r", use_dusted=True
         )
         intensity_dusted, _ = gen.generate_intensity_map(config_dusted)
 
         config_raw = TNGRenderConfig(
-            target_redshift=0.6, image_pars=image_pars_test, band='r', use_dusted=False
+            target_redshift=0.6, image_pars=image_pars_test, band="r", use_dusted=False
         )
         intensity_raw, _ = gen.generate_intensity_map(config_raw)
 
@@ -466,12 +466,12 @@ class TestEdgeCases:
                 image_pars=image_pars_test,
                 use_native_orientation=False,
                 pars={
-                    'cosi': 0.7,
-                    'theta_int': 0.0,
-                    'x0': 0.0,
-                    'y0': 0.0,
-                    'g1': 0.8,
-                    'g2': 0.8,
+                    "cosi": 0.7,
+                    "theta_int": 0.0,
+                    "x0": 0.0,
+                    "y0": 0.0,
+                    "g1": 0.8,
+                    "g2": 0.8,
                 },
             )
 
@@ -499,12 +499,12 @@ class TestSFRMap:
         """Test SFR map generation with custom orientation (uses gas offset)."""
         gen = TNGDataVectorGenerator(test_galaxy)
         pars = {
-            'theta_int': np.pi / 4,
-            'cosi': 0.7,
-            'x0': 0.0,
-            'y0': 0.0,
-            'g1': 0.0,
-            'g2': 0.0,
+            "theta_int": np.pi / 4,
+            "cosi": 0.7,
+            "x0": 0.0,
+            "y0": 0.0,
+            "g1": 0.0,
+            "g2": 0.0,
         }
         config = TNGRenderConfig(
             target_redshift=0.6,
@@ -525,12 +525,12 @@ class TestSFRMap:
 
         # Face-on
         pars_face = {
-            'theta_int': 0.0,
-            'cosi': 1.0,
-            'x0': 0.0,
-            'y0': 0.0,
-            'g1': 0.0,
-            'g2': 0.0,
+            "theta_int": 0.0,
+            "cosi": 1.0,
+            "x0": 0.0,
+            "y0": 0.0,
+            "g1": 0.0,
+            "g2": 0.0,
         }
         config_face = TNGRenderConfig(
             target_redshift=0.6,
@@ -542,12 +542,12 @@ class TestSFRMap:
 
         # Edge-on
         pars_edge = {
-            'theta_int': 0.0,
-            'cosi': 0.1,
-            'x0': 0.0,
-            'y0': 0.0,
-            'g1': 0.0,
-            'g2': 0.0,
+            "theta_int": 0.0,
+            "cosi": 0.1,
+            "x0": 0.0,
+            "y0": 0.0,
+            "g1": 0.0,
+            "g2": 0.0,
         }
         config_edge = TNGRenderConfig(
             target_redshift=0.6,
@@ -611,12 +611,12 @@ class TestTransformRoundTrip:
         native_theta_int = np.radians(gen.native_pa_deg)
 
         pars_native = {
-            'cosi': native_cosi,
-            'theta_int': native_theta_int,
-            'x0': 0.0,
-            'y0': 0.0,
-            'g1': 0.0,
-            'g2': 0.0,
+            "cosi": native_cosi,
+            "theta_int": native_theta_int,
+            "x0": 0.0,
+            "y0": 0.0,
+            "g1": 0.0,
+            "g2": 0.0,
         }
 
         config_custom = TNGRenderConfig(
@@ -662,12 +662,12 @@ class TestTransformRoundTrip:
 
         for inc_deg in inclinations:
             pars = {
-                'cosi': np.cos(np.radians(inc_deg)),
-                'theta_int': 0.0,
-                'x0': 0.0,
-                'y0': 0.0,
-                'g1': 0.0,
-                'g2': 0.0,
+                "cosi": np.cos(np.radians(inc_deg)),
+                "theta_int": 0.0,
+                "x0": 0.0,
+                "y0": 0.0,
+                "g1": 0.0,
+                "g2": 0.0,
             }
 
             config = TNGRenderConfig(
@@ -697,12 +697,12 @@ class TestTransformRoundTrip:
             int_ratio = intensity_sums[i + 1] / intensity_sums[i]
             assert (
                 0.5 < int_ratio < 2.0
-            ), f"Intensity change from inc={inclinations[i]}° to {inclinations[i+1]}° too abrupt"
+            ), f"Intensity change from inc={inclinations[i]}° to {inclinations[i + 1]}° too abrupt"
 
             vel_ratio = velocity_ranges[i + 1] / velocity_ranges[i]
             assert (
                 0.5 < vel_ratio < 2.0
-            ), f"Velocity change from inc={inclinations[i]}° to {inclinations[i+1]}° too abrupt"
+            ), f"Velocity change from inc={inclinations[i]}° to {inclinations[i + 1]}° too abrupt"
 
         print(
             f"✓ Inclination sweep passed: intensity sums = {[f'{s:.2e}' for s in intensity_sums]}"
@@ -730,21 +730,21 @@ class TestInclinationSymmetry:
         inc_2 = 135.0  # = 180° - 45°
 
         pars_1 = {
-            'cosi': np.cos(np.radians(inc_1)),
-            'theta_int': 0.0,
-            'x0': 0.0,
-            'y0': 0.0,
-            'g1': 0.0,
-            'g2': 0.0,
+            "cosi": np.cos(np.radians(inc_1)),
+            "theta_int": 0.0,
+            "x0": 0.0,
+            "y0": 0.0,
+            "g1": 0.0,
+            "g2": 0.0,
         }
 
         pars_2 = {
-            'cosi': np.cos(np.radians(inc_2)),  # Negative cos(i)!
-            'theta_int': 0.0,
-            'x0': 0.0,
-            'y0': 0.0,
-            'g1': 0.0,
-            'g2': 0.0,
+            "cosi": np.cos(np.radians(inc_2)),  # Negative cos(i)!
+            "theta_int": 0.0,
+            "x0": 0.0,
+            "y0": 0.0,
+            "g1": 0.0,
+            "g2": 0.0,
         }
 
         config_1 = TNGRenderConfig(
@@ -794,12 +794,12 @@ class TestInclinationSymmetry:
         assert cosi < 0, "Test requires inc > 90° so cos(i) < 0"
 
         pars = {
-            'cosi': cosi,
-            'theta_int': 0.0,
-            'x0': 0.0,
-            'y0': 0.0,
-            'g1': 0.0,
-            'g2': 0.0,
+            "cosi": cosi,
+            "theta_int": 0.0,
+            "x0": 0.0,
+            "y0": 0.0,
+            "g1": 0.0,
+            "g2": 0.0,
         }
 
         config = TNGRenderConfig(
@@ -833,22 +833,22 @@ class TestInclinationSymmetry:
 
         # Face-on from above (inc=0°, cos(i)=+1)
         pars_above = {
-            'cosi': 1.0,
-            'theta_int': 0.0,
-            'x0': 0.0,
-            'y0': 0.0,
-            'g1': 0.0,
-            'g2': 0.0,
+            "cosi": 1.0,
+            "theta_int": 0.0,
+            "x0": 0.0,
+            "y0": 0.0,
+            "g1": 0.0,
+            "g2": 0.0,
         }
 
         # Face-on from below (inc=180°, cos(i)=-1)
         pars_below = {
-            'cosi': -1.0,
-            'theta_int': 0.0,
-            'x0': 0.0,
-            'y0': 0.0,
-            'g1': 0.0,
-            'g2': 0.0,
+            "cosi": -1.0,
+            "theta_int": 0.0,
+            "x0": 0.0,
+            "y0": 0.0,
+            "g1": 0.0,
+            "g2": 0.0,
         }
 
         config_above = TNGRenderConfig(
@@ -985,7 +985,7 @@ class TestDiagnosticPlots:
 
     @staticmethod
     def add_scale_markers(
-        ax, image_pars, scale_bar_arcsec=1.0, color='black', crosshair_arcsec=0.3
+        ax, image_pars, scale_bar_arcsec=1.0, color="black", crosshair_arcsec=0.3
     ):
         """
         Add physical scale bar and center marker to a plot.
@@ -1027,20 +1027,20 @@ class TestDiagnosticPlots:
                 [y_start, y_start],
                 color=color,
                 linewidth=3,
-                solid_capstyle='butt',
+                solid_capstyle="butt",
             )
             ax.text(
                 x_start + scale_bar_pixels / 2,
                 y_start + 0.04 * image_pars.shape[0],
                 f'{scale_bar_arcsec}"',
                 color=color,
-                ha='center',
-                va='bottom',
+                ha="center",
+                va="bottom",
                 fontsize=8,
-                weight='bold',
+                weight="bold",
                 bbox=dict(
-                    boxstyle='round,pad=0.3',
-                    facecolor='white' if color == 'black' else 'black',
+                    boxstyle="round,pad=0.3",
+                    facecolor="white" if color == "black" else "black",
                     alpha=0.7,
                     edgecolor=color,
                 ),
@@ -1052,18 +1052,18 @@ class TestDiagnosticPlots:
             ax.plot(
                 [cx - marker_size_pix, cx + marker_size_pix],
                 [cy, cy],
-                'k-',
+                "k-",
                 linewidth=0.8,
                 alpha=0.6,
             )
             ax.plot(
                 [cx, cx],
                 [cy - marker_size_pix, cy + marker_size_pix],
-                'k-',
+                "k-",
                 linewidth=0.8,
                 alpha=0.6,
             )
-            ax.plot(cx, cy, 'k+', markersize=6, markeredgewidth=1, alpha=0.6)
+            ax.plot(cx, cy, "k+", markersize=6, markeredgewidth=1, alpha=0.6)
         else:
             # Data coordinate system (arcsec)
             fov_x = image_pars.shape[1] * image_pars.pixel_scale
@@ -1076,20 +1076,20 @@ class TestDiagnosticPlots:
                 [y_start, y_start],
                 color=color,
                 linewidth=3,
-                solid_capstyle='butt',
+                solid_capstyle="butt",
             )
             ax.text(
                 x_start + scale_bar_arcsec / 2,
                 y_start + 0.04 * fov_y,
                 f'{scale_bar_arcsec}"',
                 color=color,
-                ha='center',
-                va='bottom',
+                ha="center",
+                va="bottom",
                 fontsize=8,
-                weight='bold',
+                weight="bold",
                 bbox=dict(
-                    boxstyle='round,pad=0.3',
-                    facecolor='white' if color == 'black' else 'black',
+                    boxstyle="round,pad=0.3",
+                    facecolor="white" if color == "black" else "black",
                     alpha=0.7,
                     edgecolor=color,
                 ),
@@ -1099,18 +1099,18 @@ class TestDiagnosticPlots:
             ax.plot(
                 [-crosshair_arcsec, crosshair_arcsec],
                 [0, 0],
-                'k-',
+                "k-",
                 linewidth=0.8,
                 alpha=0.6,
             )
             ax.plot(
                 [0, 0],
                 [-crosshair_arcsec, crosshair_arcsec],
-                'k-',
+                "k-",
                 linewidth=0.8,
                 alpha=0.6,
             )
-            ax.plot(0, 0, 'k+', markersize=6, markeredgewidth=1, alpha=0.6)
+            ax.plot(0, 0, "k+", markersize=6, markeredgewidth=1, alpha=0.6)
 
     def test_all_galaxies_high_res_native(self, tng_data, output_dir):
         """
@@ -1128,7 +1128,7 @@ class TestDiagnosticPlots:
 
         n_galaxies = len(tng_data)
         image_pars = ImagePars(
-            shape=(128, 128), pixel_scale=0.05, indexing='ij'
+            shape=(128, 128), pixel_scale=0.05, indexing="ij"
         )  # High res
         target_z = 0.7
         native_z = 0.011
@@ -1142,7 +1142,7 @@ class TestDiagnosticPlots:
             gen = TNGDataVectorGenerator(galaxy)
 
             # Get metadata
-            subhalo_id = int(galaxy['subhalo']['SubhaloID'])
+            subhalo_id = int(galaxy["subhalo"]["SubhaloID"])
             inc_deg = gen.native_inclination_deg
             pa_deg = gen.native_pa_deg
             flipped = gen.flipped_from_below
@@ -1168,18 +1168,18 @@ class TestDiagnosticPlots:
             vmin, vmax = self.compute_robust_intensity_bounds(int_log, log=True)
             im_int = ax_int.imshow(
                 int_log,
-                origin='lower',
-                cmap='viridis',
-                aspect='equal',
+                origin="lower",
+                cmap="viridis",
+                aspect="equal",
                 vmin=vmin,
                 vmax=vmax,
             )
-            ax_int.set_title(f'Intensity - Galaxy {idx} (ID={subhalo_id})', fontsize=10)
+            ax_int.set_title(f"Intensity - Galaxy {idx} (ID={subhalo_id})", fontsize=10)
             # Remove axis ticks and labels for cleaner appearance
             ax_int.set_xticks([])
             ax_int.set_yticks([])
             plt.colorbar(
-                im_int, ax=ax_int, label='log$_{10}$(Flux)', fraction=0.046, pad=0.02
+                im_int, ax=ax_int, label="log$_{10}$(Flux)", fraction=0.046, pad=0.02
             )
 
             # Add metadata text
@@ -1187,17 +1187,17 @@ class TestDiagnosticPlots:
             ax_int.text(
                 0.02,
                 0.98,
-                f'inc={inc_deg:.1f}°{flipped_str}\nPA={pa_deg:.1f}°',
+                f"inc={inc_deg:.1f}°{flipped_str}\nPA={pa_deg:.1f}°",
                 transform=ax_int.transAxes,
-                va='top',
-                ha='left',
-                bbox=dict(boxstyle='round', facecolor='white', alpha=0.8),
+                va="top",
+                ha="left",
+                bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
                 fontsize=8,
             )
 
             # Add scale bar and center marker (white for intensity)
             self.add_scale_markers(
-                ax_int, image_pars, scale_bar_arcsec=1.0, color='white'
+                ax_int, image_pars, scale_bar_arcsec=1.0, color="white"
             )
 
             # Plot velocity with diverging colormap (white=0)
@@ -1205,19 +1205,19 @@ class TestDiagnosticPlots:
             vmax = np.nanmax(np.abs(velocity))
             im_vel = ax_vel.imshow(
                 velocity,
-                origin='lower',
-                cmap='RdBu_r',
-                aspect='equal',
+                origin="lower",
+                cmap="RdBu_r",
+                aspect="equal",
                 norm=MidpointNormalize(vmin=-vmax, vmax=vmax, midpoint=0),
             )
-            ax_vel.set_title(f'Velocity - Galaxy {idx} (ID={subhalo_id})', fontsize=10)
+            ax_vel.set_title(f"Velocity - Galaxy {idx} (ID={subhalo_id})", fontsize=10)
             # Remove axis ticks and labels for cleaner appearance
             ax_vel.set_xticks([])
             ax_vel.set_yticks([])
             plt.colorbar(
                 im_vel,
                 ax=ax_vel,
-                label=r'$v_\mathrm{LOS}$ [km/s]',
+                label=r"$v_\mathrm{LOS}$ [km/s]",
                 fraction=0.046,
                 pad=0.02,
             )
@@ -1233,12 +1233,12 @@ class TestDiagnosticPlots:
         # Leave room at top for suptitle (top=0.96 leaves ~4% for title)
         gs.update(top=0.96, bottom=0.01)
         fig.suptitle(
-            f'TNG50 Galaxies - Native Orientation (z={native_z:.3f}→{target_z:.1f})',
+            f"TNG50 Galaxies - Native Orientation (z={native_z:.3f}→{target_z:.1f})",
             fontsize=14,
             y=0.99,
         )
         plt.savefig(
-            output_dir / 'all_galaxies_native_highres.png', dpi=150, bbox_inches='tight'
+            output_dir / "all_galaxies_native_highres.png", dpi=150, bbox_inches="tight"
         )
         plt.close()
 
@@ -1264,7 +1264,7 @@ class TestDiagnosticPlots:
         from kl_pipe.tng.data_vectors import convert_tng_to_arcsec
 
         gen = TNGDataVectorGenerator(test_galaxy)
-        image_pars = ImagePars(shape=(64, 64), pixel_scale=0.1, indexing='ij')
+        image_pars = ImagePars(shape=(64, 64), pixel_scale=0.1, indexing="ij")
         target_z = 0.7
         fov_arcsec = image_pars.shape[0] * image_pars.pixel_scale  # Same for both dims
 
@@ -1290,7 +1290,7 @@ class TestDiagnosticPlots:
 
         # Get particle positions for scatter plots
         # Stellar particles (for intensity)
-        stellar_coords = gen.stellar['Coordinates'].copy()
+        stellar_coords = gen.stellar["Coordinates"].copy()
         stellar_center = gen._get_reference_center(
             config_cic.center_on_peak, config_cic.band, config_cic.use_dusted
         )
@@ -1301,7 +1301,7 @@ class TestDiagnosticPlots:
             :, :2
         ]  # Just drop z for native orientation
         stellar_coords_arcsec = convert_tng_to_arcsec(
-            stellar_coords_2d, gen.distance_mpc, target_redshift=target_z
+            stellar_coords_2d, target_redshift=target_z
         )
 
         # Stellar luminosities for color/size
@@ -1310,17 +1310,17 @@ class TestDiagnosticPlots:
         stellar_lum_log = np.log10(stellar_lum + 1e-10)
 
         # Gas particles (for velocity)
-        gas_coords = gen.gas['Coordinates'].copy()
+        gas_coords = gen.gas["Coordinates"].copy()
         gas_center = stellar_center  # Use same center for consistency
         gas_coords_centered = gen._center_coordinates(gas_coords, gas_center)
         gas_coords_2d = gas_coords_centered[:, :2]  # Just drop z for native orientation
         gas_coords_arcsec = convert_tng_to_arcsec(
-            gas_coords_2d, gen.distance_mpc, target_redshift=target_z
+            gas_coords_2d, target_redshift=target_z
         )
 
         # Gas velocities - must subtract systemic velocity like the gridded maps do
         # The generate_velocity_map method subtracts median velocity to center at v=0
-        gas_vel_3d = gen.gas['Velocities'].copy()
+        gas_vel_3d = gen.gas["Velocities"].copy()
         v_systemic = np.median(gas_vel_3d, axis=0)
         gas_vel_3d -= v_systemic  # Now in galaxy rest frame
         # For native orientation, LOS is along z-axis, so v_LOS = v_z
@@ -1351,15 +1351,15 @@ class TestDiagnosticPlots:
             c=lum_p,
             s=1,
             alpha=0.5,
-            cmap='viridis',
+            cmap="viridis",
             vmin=vmin_lum,
             vmax=vmax_lum,
         )
         ax.set_xlim(-fov_arcsec / 2, fov_arcsec / 2)
         ax.set_ylim(-fov_arcsec / 2, fov_arcsec / 2)
-        ax.set_aspect('equal')
-        ax.set_title('Particles (Stellar)', fontsize=11)
-        self.add_colorbar_matching_height(sc_int, ax, label='log$_{10}$(Lum)')
+        ax.set_aspect("equal")
+        ax.set_title("Particles (Stellar)", fontsize=11)
+        self.add_colorbar_matching_height(sc_int, ax, label="log$_{10}$(Lum)")
 
         # Column 1: CIC
         ax = axes[0, 1]
@@ -1367,34 +1367,34 @@ class TestDiagnosticPlots:
         vmin, vmax = self.compute_robust_intensity_bounds(int_log_cic, log=True)
         im = ax.imshow(
             int_log_cic,
-            origin='lower',
-            cmap='viridis',
-            aspect='equal',
+            origin="lower",
+            cmap="viridis",
+            aspect="equal",
             vmin=vmin,
             vmax=vmax,
         )
-        ax.set_title('CIC Gridded\n(Cloud-in-Cell)', fontsize=10)
+        ax.set_title("CIC Gridded\n(Cloud-in-Cell)", fontsize=10)
         ax.set_xticks([])
         ax.set_yticks([])
-        self.add_colorbar_matching_height(im, ax, label='log$_{10}$(Flux)')
-        self.add_scale_markers(ax, image_pars, scale_bar_arcsec=1.0, color='white')
+        self.add_colorbar_matching_height(im, ax, label="log$_{10}$(Flux)")
+        self.add_scale_markers(ax, image_pars, scale_bar_arcsec=1.0, color="white")
 
         # Column 2: NGP
         ax = axes[0, 2]
         int_log_ngp = np.log10(int_ngp + 1e-10)
         im = ax.imshow(
             int_log_ngp,
-            origin='lower',
-            cmap='viridis',
-            aspect='equal',
+            origin="lower",
+            cmap="viridis",
+            aspect="equal",
             vmin=vmin,
             vmax=vmax,
         )
-        ax.set_title('NGP Gridded\n(Nearest-Grid-Point)', fontsize=10)
+        ax.set_title("NGP Gridded\n(Nearest-Grid-Point)", fontsize=10)
         ax.set_xticks([])
         ax.set_yticks([])
-        self.add_colorbar_matching_height(im, ax, label='log$_{10}$(Flux)')
-        self.add_scale_markers(ax, image_pars, scale_bar_arcsec=1.0, color='white')
+        self.add_colorbar_matching_height(im, ax, label="log$_{10}$(Flux)")
+        self.add_scale_markers(ax, image_pars, scale_bar_arcsec=1.0, color="white")
 
         # Column 3: Residuals (CIC - NGP)
         ax = axes[0, 3]
@@ -1402,16 +1402,16 @@ class TestDiagnosticPlots:
         resid_max = np.percentile(np.abs(int_resid), 99)
         im = ax.imshow(
             int_resid,
-            origin='lower',
-            cmap='RdBu_r',
-            aspect='equal',
+            origin="lower",
+            cmap="RdBu_r",
+            aspect="equal",
             vmin=-resid_max,
             vmax=resid_max,
         )
-        ax.set_title('Residual (CIC - NGP)', fontsize=11)
+        ax.set_title("Residual (CIC - NGP)", fontsize=11)
         ax.set_xticks([])
         ax.set_yticks([])
-        self.add_colorbar_matching_height(im, ax, label='ΔFlux')
+        self.add_colorbar_matching_height(im, ax, label="ΔFlux")
 
         # === Row 1: Velocity ===
         # Column 0: Particle scatter
@@ -1434,45 +1434,45 @@ class TestDiagnosticPlots:
             c=vel_g,
             s=1,
             alpha=0.5,
-            cmap='RdBu_r',
+            cmap="RdBu_r",
             vmin=-vel_max_gridded,
             vmax=vel_max_gridded,
         )
         ax.set_xlim(-fov_arcsec / 2, fov_arcsec / 2)
         ax.set_ylim(-fov_arcsec / 2, fov_arcsec / 2)
-        ax.set_aspect('equal')
-        ax.set_title('Particles (Gas)', fontsize=11)
-        self.add_colorbar_matching_height(sc_vel, ax, label='v$_z$ [km/s]')
+        ax.set_aspect("equal")
+        ax.set_title("Particles (Gas)", fontsize=11)
+        self.add_colorbar_matching_height(sc_vel, ax, label="v$_z$ [km/s]")
 
         # Column 1: Velocity CIC
         ax = axes[1, 1]
         vel_max = max(np.nanmax(np.abs(vel_cic)), np.nanmax(np.abs(vel_ngp)))
         im = ax.imshow(
             vel_cic,
-            origin='lower',
-            cmap='RdBu_r',
-            aspect='equal',
+            origin="lower",
+            cmap="RdBu_r",
+            aspect="equal",
             norm=MidpointNormalize(vmin=-vel_max, vmax=vel_max, midpoint=0),
         )
-        ax.set_title('CIC Gridded\n(Cloud-in-Cell)', fontsize=10)
+        ax.set_title("CIC Gridded\n(Cloud-in-Cell)", fontsize=10)
         ax.set_xticks([])
         ax.set_yticks([])
-        self.add_colorbar_matching_height(im, ax, label='v$_{\\rm LOS}$ [km/s]')
+        self.add_colorbar_matching_height(im, ax, label="v$_{\\rm LOS}$ [km/s]")
         self.add_scale_markers(ax, image_pars, scale_bar_arcsec=1.0)
 
         # Column 2: Velocity NGP
         ax = axes[1, 2]
         im = ax.imshow(
             vel_ngp,
-            origin='lower',
-            cmap='RdBu_r',
-            aspect='equal',
+            origin="lower",
+            cmap="RdBu_r",
+            aspect="equal",
             norm=MidpointNormalize(vmin=-vel_max, vmax=vel_max, midpoint=0),
         )
-        ax.set_title('NGP Gridded\n(Nearest-Grid-Point)', fontsize=10)
+        ax.set_title("NGP Gridded\n(Nearest-Grid-Point)", fontsize=10)
         ax.set_xticks([])
         ax.set_yticks([])
-        self.add_colorbar_matching_height(im, ax, label='v$_{\\rm LOS}$ [km/s]')
+        self.add_colorbar_matching_height(im, ax, label="v$_{\\rm LOS}$ [km/s]")
         self.add_scale_markers(ax, image_pars, scale_bar_arcsec=1.0)
 
         # Column 3: Velocity Residuals
@@ -1486,24 +1486,24 @@ class TestDiagnosticPlots:
             vel_resid_max = 1.0
         im = ax.imshow(
             vel_resid,
-            origin='lower',
-            cmap='RdBu_r',
-            aspect='equal',
+            origin="lower",
+            cmap="RdBu_r",
+            aspect="equal",
             vmin=-vel_resid_max,
             vmax=vel_resid_max,
         )
-        ax.set_title('Residual (CIC - NGP)', fontsize=11)
+        ax.set_title("Residual (CIC - NGP)", fontsize=11)
         ax.set_xticks([])
         ax.set_yticks([])
-        self.add_colorbar_matching_height(im, ax, label='Δv [km/s]')
+        self.add_colorbar_matching_height(im, ax, label="Δv [km/s]")
 
         fig.suptitle(
-            f'Gridding Comparison: Particles → CIC → NGP → Residuals (z=0.011→{target_z})',
+            f"Gridding Comparison: Particles → CIC → NGP → Residuals (z=0.011→{target_z})",
             fontsize=13,
         )
         plt.tight_layout()
         plt.savefig(
-            output_dir / 'cic_vs_ngp_comparison.png', dpi=150, bbox_inches='tight'
+            output_dir / "cic_vs_ngp_comparison.png", dpi=150, bbox_inches="tight"
         )
         plt.close()
 
@@ -1522,7 +1522,7 @@ class TestDiagnosticPlots:
         import matplotlib.pyplot as plt
 
         gen = TNGDataVectorGenerator(test_galaxy)
-        image_pars = ImagePars(shape=(64, 64), pixel_scale=0.1, indexing='ij')
+        image_pars = ImagePars(shape=(64, 64), pixel_scale=0.1, indexing="ij")
         target_z = 0.7
 
         inc_1 = 45.0  # Viewing from above at 45° tilt
@@ -1530,12 +1530,12 @@ class TestDiagnosticPlots:
 
         # First inclination
         pars_1 = {
-            'cosi': np.cos(np.radians(inc_1)),
-            'theta_int': 0.0,
-            'x0': 0.0,
-            'y0': 0.0,
-            'g1': 0.0,
-            'g2': 0.0,
+            "cosi": np.cos(np.radians(inc_1)),
+            "theta_int": 0.0,
+            "x0": 0.0,
+            "y0": 0.0,
+            "g1": 0.0,
+            "g2": 0.0,
         }
         config_1 = TNGRenderConfig(
             target_redshift=target_z,
@@ -1549,12 +1549,12 @@ class TestDiagnosticPlots:
 
         # Second inclination
         pars_2 = {
-            'cosi': np.cos(np.radians(inc_2)),
-            'theta_int': 0.0,
-            'x0': 0.0,
-            'y0': 0.0,
-            'g1': 0.0,
-            'g2': 0.0,
+            "cosi": np.cos(np.radians(inc_2)),
+            "theta_int": 0.0,
+            "x0": 0.0,
+            "y0": 0.0,
+            "g1": 0.0,
+            "g2": 0.0,
         }
         config_2 = TNGRenderConfig(
             target_redshift=target_z,
@@ -1590,55 +1590,55 @@ class TestDiagnosticPlots:
         # Row 1: inc=45°
         im00 = axes[0, 0].imshow(
             int_log_1,
-            origin='lower',
-            cmap='viridis',
-            aspect='equal',
+            origin="lower",
+            cmap="viridis",
+            aspect="equal",
             vmin=vmin,
             vmax=vmax,
         )
-        axes[0, 0].set_title(f'Intensity - inc={inc_1}° (from above)', fontsize=11)
-        plt.colorbar(im00, ax=axes[0, 0], label='log$_{10}$(Flux)')
+        axes[0, 0].set_title(f"Intensity - inc={inc_1}° (from above)", fontsize=11)
+        plt.colorbar(im00, ax=axes[0, 0], label="log$_{10}$(Flux)")
         self.add_scale_markers(
-            axes[0, 0], image_pars, scale_bar_arcsec=1.0, color='white'
+            axes[0, 0], image_pars, scale_bar_arcsec=1.0, color="white"
         )
 
         vmax_1 = np.nanmax(np.abs(vel_1))
         im01 = axes[0, 1].imshow(
             vel_1,
-            origin='lower',
-            cmap='RdBu_r',
-            aspect='equal',
+            origin="lower",
+            cmap="RdBu_r",
+            aspect="equal",
             norm=MidpointNormalize(vmin=-vmax_1, vmax=vmax_1, midpoint=0),
         )
-        axes[0, 1].set_title(f'Velocity - inc={inc_1}° (from above)', fontsize=11)
-        plt.colorbar(im01, ax=axes[0, 1], label='v_LOS [km/s]')
+        axes[0, 1].set_title(f"Velocity - inc={inc_1}° (from above)", fontsize=11)
+        plt.colorbar(im01, ax=axes[0, 1], label="v_LOS [km/s]")
         self.add_scale_markers(axes[0, 1], image_pars, scale_bar_arcsec=1.0)
 
         # Row 2: inc=135°
         im10 = axes[1, 0].imshow(
             int_log_2,
-            origin='lower',
-            cmap='viridis',
-            aspect='equal',
+            origin="lower",
+            cmap="viridis",
+            aspect="equal",
             vmin=vmin,
             vmax=vmax,
         )
-        axes[1, 0].set_title(f'Intensity - inc={inc_2}° (from below)', fontsize=11)
-        plt.colorbar(im10, ax=axes[1, 0], label='log$_{10}$(Flux)')
+        axes[1, 0].set_title(f"Intensity - inc={inc_2}° (from below)", fontsize=11)
+        plt.colorbar(im10, ax=axes[1, 0], label="log$_{10}$(Flux)")
         self.add_scale_markers(
-            axes[1, 0], image_pars, scale_bar_arcsec=1.0, color='white'
+            axes[1, 0], image_pars, scale_bar_arcsec=1.0, color="white"
         )
 
         vmax_2 = np.nanmax(np.abs(vel_2))
         im11 = axes[1, 1].imshow(
             vel_2,
-            origin='lower',
-            cmap='RdBu_r',
-            aspect='equal',
+            origin="lower",
+            cmap="RdBu_r",
+            aspect="equal",
             norm=MidpointNormalize(vmin=-vmax_2, vmax=vmax_2, midpoint=0),
         )
-        axes[1, 1].set_title(f'Velocity - inc={inc_2}°')
-        plt.colorbar(im11, ax=axes[1, 1], label='v_LOS [km/s]')
+        axes[1, 1].set_title(f"Velocity - inc={inc_2}°")
+        plt.colorbar(im11, ax=axes[1, 1], label="v_LOS [km/s]")
 
         # Row 3: Differences
         # Use arcsinh scaling for intensity difference to see small features
@@ -1646,35 +1646,35 @@ class TestDiagnosticPlots:
         diff_max = np.nanmax(np.abs(int_diff_scaled))
         im20 = axes[2, 0].imshow(
             int_diff_scaled,
-            origin='lower',
-            cmap='RdBu_r',
+            origin="lower",
+            cmap="RdBu_r",
             vmin=-diff_max,
             vmax=diff_max,
         )
-        axes[2, 0].set_title('Intensity Difference (arcsinh scaled)', fontsize=11)
-        plt.colorbar(im20, ax=axes[2, 0], label='arcsinh(ΔFlux)')
+        axes[2, 0].set_title("Intensity Difference (arcsinh scaled)", fontsize=11)
+        plt.colorbar(im20, ax=axes[2, 0], label="arcsinh(ΔFlux)")
 
         vel_diff_max = np.nanmax(np.abs(vel_diff))
         im21 = axes[2, 1].imshow(
             vel_diff,
-            origin='lower',
-            cmap='RdBu_r',
+            origin="lower",
+            cmap="RdBu_r",
             vmin=-vel_diff_max,
             vmax=vel_diff_max,
         )
-        axes[2, 1].set_title(f'Velocity Difference')
-        plt.colorbar(im21, ax=axes[2, 1], label='Δv_LOS [km/s]')
+        axes[2, 1].set_title(f"Velocity Difference")
+        plt.colorbar(im21, ax=axes[2, 1], label="Δv_LOS [km/s]")
 
         fig.suptitle(
-            f'TNG Asymmetry: inc={inc_1}° vs inc={inc_2}°\n'
-            f'(Symmetric models would show zero difference)',
+            f"TNG Asymmetry: inc={inc_1}° vs inc={inc_2}°\n"
+            f"(Symmetric models would show zero difference)",
             fontsize=14,
         )
         plt.tight_layout()
         plt.savefig(
-            output_dir / 'symmetry_breaking_inclinations.png',
+            output_dir / "symmetry_breaking_inclinations.png",
             dpi=150,
-            bbox_inches='tight',
+            bbox_inches="tight",
         )
         plt.close()
 
@@ -1713,7 +1713,7 @@ class TestDiagnosticPlots:
         for i, pix_scale in enumerate(pixel_scales):
             npix = int(np.round(fov_arcsec / pix_scale))
             shape = (npix, npix)
-            image_pars = ImagePars(shape=shape, pixel_scale=pix_scale, indexing='ij')
+            image_pars = ImagePars(shape=shape, pixel_scale=pix_scale, indexing="ij")
 
             for j, snr in enumerate(snr_levels):
                 config = TNGRenderConfig(
@@ -1747,45 +1747,45 @@ class TestDiagnosticPlots:
                 int_log = np.log10(np.clip(intensity, 1e-10, None))
                 im_int = ax_int.imshow(
                     int_log,
-                    origin='lower',
-                    cmap='viridis',
-                    aspect='equal',
+                    origin="lower",
+                    cmap="viridis",
+                    aspect="equal",
                     vmin=vmin_int_global,
                     vmax=vmax_int_global,
                 )
 
-                snr_str = f'SNR={snr}' if snr is not None else 'No noise'
+                snr_str = f"SNR={snr}" if snr is not None else "No noise"
                 if i == 0:  # Top row
-                    ax_int.set_title(f'{snr_str}', fontsize=10)
+                    ax_int.set_title(f"{snr_str}", fontsize=10)
                 ax_int.set_xticks([])
                 ax_int.set_yticks([])
                 if j == 0:  # Left column
-                    ax_int.set_ylabel(f'{pix_scale}"/pix', fontsize=9, weight='bold')
+                    ax_int.set_ylabel(f'{pix_scale}"/pix', fontsize=9, weight="bold")
 
                 # Add colorbar
                 plt.colorbar(im_int, ax=ax_int, fraction=0.046, pad=0.04)
 
                 # Add scale markers (white for intensity)
                 self.add_scale_markers(
-                    ax_int, image_pars, scale_bar_arcsec=1.0, color='white'
+                    ax_int, image_pars, scale_bar_arcsec=1.0, color="white"
                 )
 
                 # VELOCITY (bottom 3 rows) - RdBu_r with white=0, global bounds
                 ax_vel = axes[i + 3, j]
                 im_vel = ax_vel.imshow(
                     velocity,
-                    origin='lower',
-                    cmap='RdBu_r',
+                    origin="lower",
+                    cmap="RdBu_r",
                     norm=MidpointNormalize(
                         vmin=-vmax_vel_global, vmax=vmax_vel_global, midpoint=0
                     ),
-                    aspect='equal',
+                    aspect="equal",
                 )
 
                 ax_vel.set_xticks([])
                 ax_vel.set_yticks([])
                 if j == 0:  # Left column
-                    ax_vel.set_ylabel(f'{pix_scale}"/pix', fontsize=9, weight='bold')
+                    ax_vel.set_ylabel(f'{pix_scale}"/pix', fontsize=9, weight="bold")
 
                 # Add colorbar
                 plt.colorbar(im_vel, ax=ax_vel, fraction=0.046, pad=0.04)
@@ -1797,14 +1797,14 @@ class TestDiagnosticPlots:
         fig.text(
             0.02,
             0.75,
-            'INTENSITY',
+            "INTENSITY",
             rotation=90,
-            va='center',
+            va="center",
             fontsize=12,
-            weight='bold',
+            weight="bold",
         )
         fig.text(
-            0.02, 0.25, 'VELOCITY', rotation=90, va='center', fontsize=12, weight='bold'
+            0.02, 0.25, "VELOCITY", rotation=90, va="center", fontsize=12, weight="bold"
         )
 
         fig.suptitle(
@@ -1814,7 +1814,7 @@ class TestDiagnosticPlots:
         )
         plt.tight_layout(rect=[0.03, 0, 1, 0.99])
         plt.savefig(
-            output_dir / 'resolution_snr_grid.png', dpi=150, bbox_inches='tight'
+            output_dir / "resolution_snr_grid.png", dpi=150, bbox_inches="tight"
         )
         plt.close()
 
@@ -1833,21 +1833,22 @@ class TestDiagnosticPlots:
 
         # Load SubhaloID=8
         tng_data = TNG50MockData()
-        galaxy = tng_data.get_galaxy(subhalo_id=8)
+        # galaxy = tng_data.get_galaxy(subhalo_id=8)
+        galaxy = tng_data.get_galaxy(index=0)
         gen = TNGDataVectorGenerator(galaxy)
 
         # High resolution for truth (top row) - zoom to ±2" at 0.025"/pix
         image_pars_highres = ImagePars(
-            shape=(160, 160), pixel_scale=0.025, indexing='ij'
+            shape=(160, 160), pixel_scale=0.025, indexing="ij"
         )
         # Half resolution for data vectors (bottom row)
-        image_pars_datavec = ImagePars(shape=(64, 64), pixel_scale=0.1, indexing='ij')
+        image_pars_datavec = ImagePars(shape=(64, 64), pixel_scale=0.1, indexing="ij")
         target_z = 0.6
 
         # Config for high-res truth
         config_highres = TNGRenderConfig(
             image_pars=image_pars_highres,
-            band='r',
+            band="r",
             use_native_orientation=True,
             use_cic_gridding=True,
             target_redshift=target_z,
@@ -1856,7 +1857,7 @@ class TestDiagnosticPlots:
         # Config for lower-res data vectors
         config_datavec = TNGRenderConfig(
             image_pars=image_pars_datavec,
-            band='r',
+            band="r",
             use_native_orientation=True,
             use_cic_gridding=True,
             target_redshift=target_z,
@@ -1889,19 +1890,19 @@ class TestDiagnosticPlots:
         vmin_int, vmax_int = self.compute_robust_intensity_bounds(int_log, log=True)
         im00 = ax00.imshow(
             int_log,
-            origin='lower',
-            cmap='viridis',
-            aspect='equal',
+            origin="lower",
+            cmap="viridis",
+            aspect="equal",
             vmin=vmin_int,
             vmax=vmax_int,
             extent=extent_highres,
         )
-        ax00.set_title('r-band Flux (Truth)', fontsize=12, weight='bold')
-        ax00.set_xlabel('X [arcsec]', fontsize=10)
-        ax00.set_ylabel('Y [arcsec]', fontsize=10)
-        self.add_colorbar_matching_height(im00, ax00, label='log$_{10}$(Flux)')
+        ax00.set_title("r-band Flux (Truth)", fontsize=12, weight="bold")
+        ax00.set_xlabel("X [arcsec]", fontsize=10)
+        ax00.set_ylabel("Y [arcsec]", fontsize=10)
+        self.add_colorbar_matching_height(im00, ax00, label="log$_{10}$(Flux)")
         self.add_scale_markers(
-            ax00, image_pars_highres, scale_bar_arcsec=0.5, color='white'
+            ax00, image_pars_highres, scale_bar_arcsec=0.5, color="white"
         )
         ax00.text(
             0.95,
@@ -1909,9 +1910,9 @@ class TestDiagnosticPlots:
             'pix=0.025"',
             transform=ax00.transAxes,
             fontsize=9,
-            va='top',
-            ha='right',
-            bbox=dict(boxstyle='round', facecolor='white', alpha=0.8),
+            va="top",
+            ha="right",
+            bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
         )
 
         # Top middle: Hα flux (from SFR)
@@ -1920,19 +1921,19 @@ class TestDiagnosticPlots:
         vmin_ha, vmax_ha = self.compute_robust_intensity_bounds(halpha_log, log=True)
         im01 = ax01.imshow(
             halpha_log,
-            origin='lower',
-            cmap='viridis',
-            aspect='equal',
+            origin="lower",
+            cmap="viridis",
+            aspect="equal",
             vmin=vmin_ha,
             vmax=vmax_ha,
             extent=extent_highres,
         )
-        ax01.set_title('Hα Flux (SFR proxy, Truth)', fontsize=12, weight='bold')
-        ax01.set_xlabel('X [arcsec]', fontsize=10)
-        ax01.set_ylabel('Y [arcsec]', fontsize=10)
-        self.add_colorbar_matching_height(im01, ax01, label='log$_{10}$(SFR)')
+        ax01.set_title("Hα Flux (SFR proxy, Truth)", fontsize=12, weight="bold")
+        ax01.set_xlabel("X [arcsec]", fontsize=10)
+        ax01.set_ylabel("Y [arcsec]", fontsize=10)
+        self.add_colorbar_matching_height(im01, ax01, label="log$_{10}$(SFR)")
         self.add_scale_markers(
-            ax01, image_pars_highres, scale_bar_arcsec=0.5, color='white'
+            ax01, image_pars_highres, scale_bar_arcsec=0.5, color="white"
         )
         ax01.text(
             0.95,
@@ -1940,9 +1941,9 @@ class TestDiagnosticPlots:
             'pix=0.025"',
             transform=ax01.transAxes,
             fontsize=9,
-            va='top',
-            ha='right',
-            bbox=dict(boxstyle='round', facecolor='white', alpha=0.8),
+            va="top",
+            ha="right",
+            bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
         )
 
         # Top right: LoS velocity
@@ -1950,16 +1951,16 @@ class TestDiagnosticPlots:
         vmax_vel = np.nanmax(np.abs(vel_clean))
         im02 = ax02.imshow(
             vel_clean,
-            origin='lower',
-            cmap='RdBu_r',
-            aspect='equal',
+            origin="lower",
+            cmap="RdBu_r",
+            aspect="equal",
             norm=MidpointNormalize(vmin=-vmax_vel, vmax=vmax_vel, midpoint=0),
             extent=extent_highres,
         )
-        ax02.set_title('LoS Velocity (Truth)', fontsize=12, weight='bold')
-        ax02.set_xlabel('X [arcsec]', fontsize=10)
-        ax02.set_ylabel('Y [arcsec]', fontsize=10)
-        self.add_colorbar_matching_height(im02, ax02, label=r'$v_\mathrm{LOS}$ [km/s]')
+        ax02.set_title("LoS Velocity (Truth)", fontsize=12, weight="bold")
+        ax02.set_xlabel("X [arcsec]", fontsize=10)
+        ax02.set_ylabel("Y [arcsec]", fontsize=10)
+        self.add_colorbar_matching_height(im02, ax02, label=r"$v_\mathrm{LOS}$ [km/s]")
         self.add_scale_markers(ax02, image_pars_highres, scale_bar_arcsec=0.5)
         ax02.text(
             0.95,
@@ -1967,9 +1968,9 @@ class TestDiagnosticPlots:
             'pix=0.025"',
             transform=ax02.transAxes,
             fontsize=9,
-            va='top',
-            ha='right',
-            bbox=dict(boxstyle='round', facecolor='white', alpha=0.8),
+            va="top",
+            ha="right",
+            bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
         )
 
         # Bottom row: Lower-res with noise (Data Vectors)
@@ -1983,19 +1984,19 @@ class TestDiagnosticPlots:
         )
         im10 = ax10.imshow(
             int_noisy_log,
-            origin='lower',
-            cmap='viridis',
-            aspect='equal',
+            origin="lower",
+            cmap="viridis",
+            aspect="equal",
             vmin=vmin_int_noisy,
             vmax=vmax_int_noisy,
             extent=extent_datavec,
         )
-        ax10.set_title('r-band DataVector (SNR=250)', fontsize=12, weight='bold')
-        ax10.set_xlabel('X [arcsec]', fontsize=10)
-        ax10.set_ylabel('Y [arcsec]', fontsize=10)
-        self.add_colorbar_matching_height(im10, ax10, label='log$_{10}$(Flux)')
+        ax10.set_title("r-band DataVector (SNR=250)", fontsize=12, weight="bold")
+        ax10.set_xlabel("X [arcsec]", fontsize=10)
+        ax10.set_ylabel("Y [arcsec]", fontsize=10)
+        self.add_colorbar_matching_height(im10, ax10, label="log$_{10}$(Flux)")
         self.add_scale_markers(
-            ax10, image_pars_datavec, scale_bar_arcsec=1.0, color='white'
+            ax10, image_pars_datavec, scale_bar_arcsec=1.0, color="white"
         )
         ax10.text(
             0.95,
@@ -2003,9 +2004,9 @@ class TestDiagnosticPlots:
             'pix=0.1"',
             transform=ax10.transAxes,
             fontsize=9,
-            va='top',
-            ha='right',
-            bbox=dict(boxstyle='round', facecolor='white', alpha=0.8),
+            va="top",
+            ha="right",
+            bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
         )
 
         # Bottom middle: Hα DataVector - compute separate bounds for noisy data
@@ -2018,19 +2019,19 @@ class TestDiagnosticPlots:
         )
         im11 = ax11.imshow(
             halpha_noisy_log,
-            origin='lower',
-            cmap='viridis',
-            aspect='equal',
+            origin="lower",
+            cmap="viridis",
+            aspect="equal",
             vmin=vmin_ha_noisy,
             vmax=vmax_ha_noisy,
             extent=extent_datavec,
         )
-        ax11.set_title('Hα DataVector (SNR=250)', fontsize=12, weight='bold')
-        ax11.set_xlabel('X [arcsec]', fontsize=10)
-        ax11.set_ylabel('Y [arcsec]', fontsize=10)
-        self.add_colorbar_matching_height(im11, ax11, label='log$_{10}$(SFR)')
+        ax11.set_title("Hα DataVector (SNR=250)", fontsize=12, weight="bold")
+        ax11.set_xlabel("X [arcsec]", fontsize=10)
+        ax11.set_ylabel("Y [arcsec]", fontsize=10)
+        self.add_colorbar_matching_height(im11, ax11, label="log$_{10}$(SFR)")
         self.add_scale_markers(
-            ax11, image_pars_datavec, scale_bar_arcsec=1.0, color='white'
+            ax11, image_pars_datavec, scale_bar_arcsec=1.0, color="white"
         )
         ax11.text(
             0.95,
@@ -2038,25 +2039,25 @@ class TestDiagnosticPlots:
             'pix=0.1"',
             transform=ax11.transAxes,
             fontsize=9,
-            va='top',
-            ha='right',
-            bbox=dict(boxstyle='round', facecolor='white', alpha=0.8),
+            va="top",
+            ha="right",
+            bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
         )
 
         # Bottom right: Velocity DataVector
         ax12 = fig.add_subplot(gs[1, 2])
         im12 = ax12.imshow(
             vel_noisy,
-            origin='lower',
-            cmap='RdBu_r',
-            aspect='equal',
+            origin="lower",
+            cmap="RdBu_r",
+            aspect="equal",
             norm=MidpointNormalize(vmin=-vmax_vel, vmax=vmax_vel, midpoint=0),
             extent=extent_datavec,
         )
-        ax12.set_title('Velocity DataVector (SNR=50)', fontsize=12, weight='bold')
-        ax12.set_xlabel('X [arcsec]', fontsize=10)
-        ax12.set_ylabel('Y [arcsec]', fontsize=10)
-        self.add_colorbar_matching_height(im12, ax12, label=r'$v_\mathrm{LOS}$ [km/s]')
+        ax12.set_title("Velocity DataVector (SNR=50)", fontsize=12, weight="bold")
+        ax12.set_xlabel("X [arcsec]", fontsize=10)
+        ax12.set_ylabel("Y [arcsec]", fontsize=10)
+        self.add_colorbar_matching_height(im12, ax12, label=r"$v_\mathrm{LOS}$ [km/s]")
         self.add_scale_markers(ax12, image_pars_datavec, scale_bar_arcsec=1.0)
         ax12.text(
             0.95,
@@ -2064,14 +2065,14 @@ class TestDiagnosticPlots:
             'pix=0.1"',
             transform=ax12.transAxes,
             fontsize=9,
-            va='top',
-            ha='right',
-            bbox=dict(boxstyle='round', facecolor='white', alpha=0.8),
+            va="top",
+            ha="right",
+            bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
         )
 
-        fig.suptitle(f'TNG50 Galaxy (SubhaloID=8, z={target_z})', fontsize=14, y=0.98)
+        fig.suptitle(f"TNG50 Galaxy (SubhaloID=8, z={target_z})", fontsize=14, y=0.98)
         plt.savefig(
-            output_dir / 'glamour_shot_subhalo8.png', dpi=150, bbox_inches='tight'
+            output_dir / "glamour_shot_subhalo8.png", dpi=150, bbox_inches="tight"
         )
         plt.close()
 
@@ -2098,12 +2099,13 @@ class TestDiagnosticPlots:
 
         # Load SubhaloID=8
         tng_data = TNG50MockData()
-        galaxy = tng_data.get_galaxy(subhalo_id=8)
+        # galaxy = tng_data.get_galaxy(subhalo_id=8)
+        galaxy = tng_data.get_galaxy(index=0)
         gen = TNGDataVectorGenerator(galaxy)
 
         # Zoomed out view: larger FOV
         image_pars = ImagePars(
-            shape=(80, 80), pixel_scale=0.05, indexing='ij'
+            shape=(80, 80), pixel_scale=0.05, indexing="ij"
         )  # 4 arcsec FOV
         target_z = 0.5  # Slightly closer for larger apparent size
         snr = None
@@ -2130,7 +2132,7 @@ class TestDiagnosticPlots:
             # Native orientation
             config_native = TNGRenderConfig(
                 image_pars=image_pars,
-                band='r',
+                band="r",
                 use_native_orientation=True,
                 use_cic_gridding=True,
                 target_redshift=target_z,
@@ -2141,23 +2143,23 @@ class TestDiagnosticPlots:
             all_velocities.append(vel_native)
             native_cosi = np.cos(np.deg2rad(gen.native_inclination_deg))
             titles_int.append(
-                f'Native\ninc={gen.native_inclination_deg:.1f}°\ncos(i)={native_cosi:.2f}'
+                f"Native\ninc={gen.native_inclination_deg:.1f}°\ncos(i)={native_cosi:.2f}"
             )
-            titles_vel.append('')
+            titles_vel.append("")
 
             # Custom orientations
             for cosi, inc_deg in zip(cosi_vals, inc_deg_vals):
                 pars = {
-                    'cosi': cosi,
-                    'theta_int': np.deg2rad(gen.native_pa_deg),
-                    'g1': 0.0,
-                    'g2': 0.0,
-                    'x0': 0.0,
-                    'y0': 0.0,
+                    "cosi": cosi,
+                    "theta_int": np.deg2rad(gen.native_pa_deg),
+                    "g1": 0.0,
+                    "g2": 0.0,
+                    "x0": 0.0,
+                    "y0": 0.0,
                 }
                 config = TNGRenderConfig(
                     image_pars=image_pars,
-                    band='r',
+                    band="r",
                     use_native_orientation=False,
                     use_cic_gridding=True,
                     target_redshift=target_z,
@@ -2168,8 +2170,8 @@ class TestDiagnosticPlots:
                 velocity, _ = gen.generate_velocity_map(config, snr=snr, seed=42)
                 all_intensities.append(intensity)
                 all_velocities.append(velocity)
-                titles_int.append(f'inc={inc_deg:.0f}°\ncos(i)={cosi:.1f}')
-                titles_vel.append('')
+                titles_int.append(f"inc={inc_deg:.0f}°\ncos(i)={cosi:.1f}")
+                titles_vel.append("")
 
             # Compute global colorbar ranges
             # Use np.clip to avoid log10 of negative/zero values
@@ -2205,9 +2207,9 @@ class TestDiagnosticPlots:
                 int_log = np.log10(np.clip(intensity, 1e-10, None))
                 im = grid_int[idx].imshow(
                     int_log,
-                    origin='lower',
-                    cmap='viridis',
-                    aspect='equal',
+                    origin="lower",
+                    cmap="viridis",
+                    aspect="equal",
                     vmin=vmin_int,
                     vmax=vmax_int,
                     extent=extent,
@@ -2217,12 +2219,12 @@ class TestDiagnosticPlots:
                 grid_int[idx].set_yticks([])
                 if idx == 0:  # Scale bar on native column
                     self.add_scale_markers(
-                        grid_int[idx], image_pars, scale_bar_arcsec=1.0, color='white'
+                        grid_int[idx], image_pars, scale_bar_arcsec=1.0, color="white"
                     )
 
-            grid_int[0].set_ylabel('Intensity', fontsize=10, weight='bold')
+            grid_int[0].set_ylabel("Intensity", fontsize=10, weight="bold")
             grid_int.cbar_axes[0].colorbar(im)
-            grid_int.cbar_axes[0].set_ylabel('log(Flux)', fontsize=9)
+            grid_int.cbar_axes[0].set_ylabel("log(Flux)", fontsize=9)
 
             # Velocity row (bottom)
             grid_vel = ImageGrid(
@@ -2240,9 +2242,9 @@ class TestDiagnosticPlots:
             for idx, velocity in enumerate(all_velocities):
                 im = grid_vel[idx].imshow(
                     velocity,
-                    origin='lower',
-                    cmap='RdBu_r',
-                    aspect='equal',
+                    origin="lower",
+                    cmap="RdBu_r",
+                    aspect="equal",
                     norm=MidpointNormalize(vmin=-vmax_vel, vmax=vmax_vel, midpoint=0),
                     extent=extent,
                 )
@@ -2253,21 +2255,21 @@ class TestDiagnosticPlots:
                         grid_vel[idx], image_pars, scale_bar_arcsec=1.0
                     )
 
-            grid_vel[0].set_ylabel('Velocity', fontsize=10, weight='bold')
+            grid_vel[0].set_ylabel("Velocity", fontsize=10, weight="bold")
             grid_vel.cbar_axes[0].colorbar(im)
-            grid_vel.cbar_axes[0].set_ylabel('v [km/s]', fontsize=9)
+            grid_vel.cbar_axes[0].set_ylabel("v [km/s]", fontsize=9)
 
             # Add info about gas-stellar offset
             offset_angle = gen._gas_stellar_L_angle_deg
             fig.suptitle(
-                f'TNG50 SubhaloID=8: Inclination Sweep ({mode_title})\n'
-                f'Gas-stellar L offset: {offset_angle:.1f}°, z={target_z}',
+                f"TNG50 SubhaloID=8: Inclination Sweep ({mode_title})\n"
+                f"Gas-stellar L offset: {offset_angle:.1f}°, z={target_z}",
                 fontsize=11,
                 y=1.02,
             )
 
-            out_path = output_dir / f'orientation_sweep_inclination_{mode_label}.png'
-            plt.savefig(out_path, dpi=150, bbox_inches='tight')
+            out_path = output_dir / f"orientation_sweep_inclination_{mode_label}.png"
+            plt.savefig(out_path, dpi=150, bbox_inches="tight")
             plt.close()
 
             print(f"✓ Saved inclination sweep ({mode_label}): {out_path}")
@@ -2291,7 +2293,7 @@ class TestDiagnosticPlots:
         galaxy_indices = range(min(5, len(tng_data)))
 
         # Common parameters
-        image_pars = ImagePars(shape=(80, 80), pixel_scale=0.05, indexing='ij')
+        image_pars = ImagePars(shape=(80, 80), pixel_scale=0.05, indexing="ij")
         target_z = 0.5
         snr = None
         preserve_offset = True  # Use gas offset preserved mode
@@ -2308,7 +2310,7 @@ class TestDiagnosticPlots:
         for gal_idx in galaxy_indices:
             galaxy = tng_data[gal_idx]
             gen = TNGDataVectorGenerator(galaxy)
-            subhalo_id = galaxy['subhalo']['SubhaloID']
+            subhalo_id = galaxy["subhalo"]["SubhaloID"]
 
             print(
                 f"Generating inclination sweep for galaxy {gal_idx} (SubhaloID={subhalo_id})..."
@@ -2317,19 +2319,19 @@ class TestDiagnosticPlots:
             # Collect orientation diagnostics for summary
             orientation_summary.append(
                 {
-                    'SubhaloID': subhalo_id,
-                    'Catalog_Inc_deg': gen.native_inclination_deg,
-                    'Kinematic_Inc_deg': getattr(
-                        gen, '_kinematic_inc_stellar_deg', 0.0
+                    "SubhaloID": subhalo_id,
+                    "Catalog_Inc_deg": gen.native_inclination_deg,
+                    "Kinematic_Inc_deg": getattr(
+                        gen, "_kinematic_inc_stellar_deg", 0.0
                     ),
-                    'Catalog_vs_Kinematic_Offset_deg': getattr(
-                        gen, '_catalog_vs_kinematic_offset_deg', 0.0
+                    "Catalog_vs_Kinematic_Offset_deg": getattr(
+                        gen, "_catalog_vs_kinematic_offset_deg", 0.0
                     ),
-                    'Gas_Stellar_L_Offset_deg': getattr(
-                        gen, '_gas_stellar_L_angle_deg', 0.0
+                    "Gas_Stellar_L_Offset_deg": getattr(
+                        gen, "_gas_stellar_L_angle_deg", 0.0
                     ),
-                    'Kinematic_Inc_Gas_deg': getattr(
-                        gen, '_kinematic_inc_gas_deg', 0.0
+                    "Kinematic_Inc_Gas_deg": getattr(
+                        gen, "_kinematic_inc_gas_deg", 0.0
                     ),
                 }
             )
@@ -2343,7 +2345,7 @@ class TestDiagnosticPlots:
             # Native orientation
             config_native = TNGRenderConfig(
                 image_pars=image_pars,
-                band='r',
+                band="r",
                 use_native_orientation=True,
                 use_cic_gridding=True,
                 target_redshift=target_z,
@@ -2354,23 +2356,23 @@ class TestDiagnosticPlots:
             all_velocities.append(vel_native)
             native_cosi = np.cos(np.deg2rad(gen.native_inclination_deg))
             titles_int.append(
-                f'Native\ninc={gen.native_inclination_deg:.1f}°\ncos(i)={native_cosi:.2f}'
+                f"Native\ninc={gen.native_inclination_deg:.1f}°\ncos(i)={native_cosi:.2f}"
             )
-            titles_vel.append('')
+            titles_vel.append("")
 
             # Custom orientations
             for cosi, inc_deg in zip(cosi_vals, inc_deg_vals):
                 pars = {
-                    'cosi': cosi,
-                    'theta_int': np.deg2rad(gen.native_pa_deg),
-                    'g1': 0.0,
-                    'g2': 0.0,
-                    'x0': 0.0,
-                    'y0': 0.0,
+                    "cosi": cosi,
+                    "theta_int": np.deg2rad(gen.native_pa_deg),
+                    "g1": 0.0,
+                    "g2": 0.0,
+                    "x0": 0.0,
+                    "y0": 0.0,
                 }
                 config = TNGRenderConfig(
                     image_pars=image_pars,
-                    band='r',
+                    band="r",
                     use_native_orientation=False,
                     use_cic_gridding=True,
                     target_redshift=target_z,
@@ -2381,8 +2383,8 @@ class TestDiagnosticPlots:
                 velocity, _ = gen.generate_velocity_map(config, snr=snr, seed=42)
                 all_intensities.append(intensity)
                 all_velocities.append(velocity)
-                titles_int.append(f'inc={inc_deg:.0f}°\ncos(i)={cosi:.1f}')
-                titles_vel.append('')
+                titles_int.append(f"inc={inc_deg:.0f}°\ncos(i)={cosi:.1f}")
+                titles_vel.append("")
 
             # Compute colorbar ranges
             # Use np.clip to avoid log10 of negative/zero values
@@ -2419,19 +2421,19 @@ class TestDiagnosticPlots:
                 im = grid_int[idx].imshow(
                     int_log,
                     extent=extent,
-                    origin='lower',
-                    cmap='viridis',
+                    origin="lower",
+                    cmap="viridis",
                     vmin=vmin_int,
                     vmax=vmax_int,
-                    interpolation='nearest',
+                    interpolation="nearest",
                 )
                 grid_int[idx].set_title(title, fontsize=8)
                 if idx == 0:
-                    grid_int[idx].set_ylabel('Intensity', fontsize=10)
+                    grid_int[idx].set_ylabel("Intensity", fontsize=10)
                 grid_int[idx].tick_params(labelsize=6)
 
             grid_int.cbar_axes[0].colorbar(im)
-            grid_int.cbar_axes[0].set_ylabel('log(Flux)', fontsize=8)
+            grid_int.cbar_axes[0].set_ylabel("log(Flux)", fontsize=8)
 
             # Velocity row
             grid_vel = ImageGrid(
@@ -2450,26 +2452,26 @@ class TestDiagnosticPlots:
                 im = grid_vel[idx].imshow(
                     velocity,
                     extent=extent,
-                    origin='lower',
-                    cmap='RdBu_r',
+                    origin="lower",
+                    cmap="RdBu_r",
                     vmin=-vmax_vel,
                     vmax=vmax_vel,
-                    interpolation='nearest',
+                    interpolation="nearest",
                 )
                 grid_vel[idx].set_title(title, fontsize=8)
                 if idx == 0:
-                    grid_vel[idx].set_ylabel('Velocity', fontsize=10)
+                    grid_vel[idx].set_ylabel("Velocity", fontsize=10)
                 grid_vel[idx].tick_params(labelsize=6)
 
             grid_vel.cbar_axes[0].colorbar(im)
-            grid_vel.cbar_axes[0].set_ylabel('v [km/s]', fontsize=8)
+            grid_vel.cbar_axes[0].set_ylabel("v [km/s]", fontsize=8)
 
             # Quantitative diagnostic: compute vertical extent at each inclination
             print(f"\n  SubhaloID={subhalo_id} Vertical Extent Analysis:")
             print(
                 f"  {'Inclination':<12} {'cos(i)':<8} {'RMS Height':<12} {'90th Pct':<12}"
             )
-            print(f"  {'-'*50}")
+            print(f"  {'-' * 50}")
 
             vertical_extents_rms = []
             vertical_extents_90 = []
@@ -2520,20 +2522,20 @@ class TestDiagnosticPlots:
 
             # Save diagnostic data to CSV
             csv_path = (
-                output_dir / f'vertical_extent_diagnostic_subhalo{subhalo_id}.csv'
+                output_dir / f"vertical_extent_diagnostic_subhalo{subhalo_id}.csv"
             )
             import csv
 
-            with open(csv_path, 'w', newline='') as csvfile:
+            with open(csv_path, "w", newline="") as csvfile:
                 writer = csv.writer(csvfile)
                 writer.writerow(
                     [
-                        'SubhaloID',
-                        'Inclination_deg',
-                        'cos_i',
-                        'RMS_Height_arcsec',
-                        'P90_Height_arcsec',
-                        'is_native',
+                        "SubhaloID",
+                        "Inclination_deg",
+                        "cos_i",
+                        "RMS_Height_arcsec",
+                        "P90_Height_arcsec",
+                        "is_native",
                     ]
                 )
 
@@ -2565,25 +2567,25 @@ class TestDiagnosticPlots:
             print(f"  ✓ Saved diagnostic CSV: {csv_path}")
 
             # Title with enhanced diagnostics
-            gas_stellar_angle = getattr(gen, '_gas_stellar_L_angle_deg', 0.0)
-            kinematic_inc = getattr(gen, '_kinematic_inc_stellar_deg', 0.0)
+            gas_stellar_angle = getattr(gen, "_gas_stellar_L_angle_deg", 0.0)
+            kinematic_inc = getattr(gen, "_kinematic_inc_stellar_deg", 0.0)
             catalog_kinematic_offset = getattr(
-                gen, '_catalog_vs_kinematic_offset_deg', 0.0
+                gen, "_catalog_vs_kinematic_offset_deg", 0.0
             )
 
             fig.suptitle(
-                f'TNG50 SubhaloID={subhalo_id}: Inclination Sweep (Gas offset preserved)\n'
-                f'Gas-stellar L offset: {gas_stellar_angle:.1f}°, '
-                f'Catalog inc: {gen.native_inclination_deg:.1f}° vs Kinematic inc: {kinematic_inc:.1f}° '
-                f'(Δ={catalog_kinematic_offset:.1f}°), z={target_z}',
+                f"TNG50 SubhaloID={subhalo_id}: Inclination Sweep (Gas offset preserved)\n"
+                f"Gas-stellar L offset: {gas_stellar_angle:.1f}°, "
+                f"Catalog inc: {gen.native_inclination_deg:.1f}° vs Kinematic inc: {kinematic_inc:.1f}° "
+                f"(Δ={catalog_kinematic_offset:.1f}°), z={target_z}",
                 fontsize=10,
                 y=0.98,
             )
 
             out_path = (
-                output_dir / f'orientation_sweep_inclination_subhalo{subhalo_id}.png'
+                output_dir / f"orientation_sweep_inclination_subhalo{subhalo_id}.png"
             )
-            plt.savefig(out_path, dpi=150, bbox_inches='tight')
+            plt.savefig(out_path, dpi=150, bbox_inches="tight")
             plt.close()
 
             # Print diagnostic summary
@@ -2596,15 +2598,15 @@ class TestDiagnosticPlots:
             print(f"\n  ✓ Saved: {out_path}")
 
         # Write summary CSV with orientation diagnostics for all galaxies
-        summary_csv_path = output_dir / 'orientation_diagnostics_summary.csv'
-        with open(summary_csv_path, 'w', newline='') as csvfile:
+        summary_csv_path = output_dir / "orientation_diagnostics_summary.csv"
+        with open(summary_csv_path, "w", newline="") as csvfile:
             fieldnames = [
-                'SubhaloID',
-                'Catalog_Inc_deg',
-                'Kinematic_Inc_deg',
-                'Catalog_vs_Kinematic_Offset_deg',
-                'Gas_Stellar_L_Offset_deg',
-                'Kinematic_Inc_Gas_deg',
+                "SubhaloID",
+                "Catalog_Inc_deg",
+                "Kinematic_Inc_deg",
+                "Catalog_vs_Kinematic_Offset_deg",
+                "Gas_Stellar_L_Offset_deg",
+                "Kinematic_Inc_Gas_deg",
             ]
             writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
             writer.writeheader()
@@ -2650,12 +2652,13 @@ class TestDiagnosticPlots:
 
         # Load SubhaloID=8
         tng_data = TNG50MockData()
-        galaxy = tng_data.get_galaxy(subhalo_id=8)
+        # galaxy = tng_data.get_galaxy(subhalo_id=8)
+        galaxy = tng_data.get_galaxy(index=0)
         gen = TNGDataVectorGenerator(galaxy)
 
         # Zoomed out view
         image_pars = ImagePars(
-            shape=(80, 80), pixel_scale=0.05, indexing='ij'
+            shape=(80, 80), pixel_scale=0.05, indexing="ij"
         )  # 4 arcsec FOV
         target_z = 0.5
         snr = None
@@ -2679,16 +2682,16 @@ class TestDiagnosticPlots:
             all_velocities = []
             for pa_deg in pa_deg_vals:
                 pars = {
-                    'cosi': native_cosi,
-                    'theta_int': np.deg2rad(pa_deg),
-                    'g1': 0.0,
-                    'g2': 0.0,
-                    'x0': 0.0,
-                    'y0': 0.0,
+                    "cosi": native_cosi,
+                    "theta_int": np.deg2rad(pa_deg),
+                    "g1": 0.0,
+                    "g2": 0.0,
+                    "x0": 0.0,
+                    "y0": 0.0,
                 }
                 config = TNGRenderConfig(
                     image_pars=image_pars,
-                    band='r',
+                    band="r",
                     use_native_orientation=False,
                     use_cic_gridding=True,
                     target_redshift=target_z,
@@ -2735,24 +2738,24 @@ class TestDiagnosticPlots:
                 int_log = np.log10(intensity + 1e-10)
                 im = grid_int[idx].imshow(
                     int_log,
-                    origin='lower',
-                    cmap='viridis',
-                    aspect='equal',
+                    origin="lower",
+                    cmap="viridis",
+                    aspect="equal",
                     vmin=vmin_int,
                     vmax=vmax_int,
                     extent=extent,
                 )
-                grid_int[idx].set_title(f'PA={pa_deg:.0f}°', fontsize=9)
+                grid_int[idx].set_title(f"PA={pa_deg:.0f}°", fontsize=9)
                 grid_int[idx].set_xticks([])
                 grid_int[idx].set_yticks([])
                 if idx == 0:  # Scale bar on first column
                     self.add_scale_markers(
-                        grid_int[idx], image_pars, scale_bar_arcsec=1.0, color='white'
+                        grid_int[idx], image_pars, scale_bar_arcsec=1.0, color="white"
                     )
 
-            grid_int[0].set_ylabel('Intensity', fontsize=10, weight='bold')
+            grid_int[0].set_ylabel("Intensity", fontsize=10, weight="bold")
             grid_int.cbar_axes[0].colorbar(im)
-            grid_int.cbar_axes[0].set_ylabel('log(Flux)', fontsize=9)
+            grid_int.cbar_axes[0].set_ylabel("log(Flux)", fontsize=9)
 
             # Velocity row (bottom)
             grid_vel = ImageGrid(
@@ -2770,9 +2773,9 @@ class TestDiagnosticPlots:
             for idx, velocity in enumerate(all_velocities):
                 im = grid_vel[idx].imshow(
                     velocity,
-                    origin='lower',
-                    cmap='RdBu_r',
-                    aspect='equal',
+                    origin="lower",
+                    cmap="RdBu_r",
+                    aspect="equal",
                     norm=MidpointNormalize(vmin=-vmax_vel, vmax=vmax_vel, midpoint=0),
                     extent=extent,
                 )
@@ -2783,21 +2786,21 @@ class TestDiagnosticPlots:
                         grid_vel[idx], image_pars, scale_bar_arcsec=1.0
                     )
 
-            grid_vel[0].set_ylabel('Velocity', fontsize=10, weight='bold')
+            grid_vel[0].set_ylabel("Velocity", fontsize=10, weight="bold")
             grid_vel.cbar_axes[0].colorbar(im)
-            grid_vel.cbar_axes[0].set_ylabel('v [km/s]', fontsize=9)
+            grid_vel.cbar_axes[0].set_ylabel("v [km/s]", fontsize=9)
 
             # Add info about gas-stellar offset
             offset_angle = gen._gas_stellar_L_angle_deg
             fig.suptitle(
-                f'TNG50 SubhaloID=8: PA Sweep ({mode_title})\n'
-                f'inc={gen.native_inclination_deg:.1f}°, Gas-stellar L offset: {offset_angle:.1f}°',
+                f"TNG50 SubhaloID=8: PA Sweep ({mode_title})\n"
+                f"inc={gen.native_inclination_deg:.1f}°, Gas-stellar L offset: {offset_angle:.1f}°",
                 fontsize=11,
                 y=1.02,
             )
 
-            out_path = output_dir / f'orientation_sweep_pa_{mode_label}.png'
-            plt.savefig(out_path, dpi=150, bbox_inches='tight')
+            out_path = output_dir / f"orientation_sweep_pa_{mode_label}.png"
+            plt.savefig(out_path, dpi=150, bbox_inches="tight")
             plt.close()
 
             print(f"✓ Saved PA sweep ({mode_label}): {out_path}")

--- a/tests/test_tng_data_vectors.py
+++ b/tests/test_tng_data_vectors.py
@@ -17,13 +17,13 @@ from kl_pipe.plotting import MidpointNormalize
 pytestmark = pytest.mark.tng50
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def tng_data():
     """Load TNG50 data once."""
     return TNG50MockData()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def test_galaxy(tng_data):
     """Get first galaxy."""
     return tng_data[0]
@@ -32,7 +32,7 @@ def test_galaxy(tng_data):
 @pytest.fixture
 def image_pars_test():
     """Standard test image parameters."""
-    return ImagePars(shape=(64, 64), pixel_scale=0.1, indexing="ij")
+    return ImagePars(shape=(64, 64), pixel_scale=0.1, indexing='ij')
 
 
 @pytest.fixture
@@ -50,7 +50,7 @@ class TestBasicRendering:
         config = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band="r",
+            band='r',
             use_native_orientation=True,
             use_cic_gridding=True,
         )
@@ -69,7 +69,7 @@ class TestBasicRendering:
         config = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band="r",
+            band='r',
             use_native_orientation=True,
             use_cic_gridding=True,
         )
@@ -90,17 +90,17 @@ class TestOrientation:
         """Test rendering at face-on orientation."""
         gen = TNGDataVectorGenerator(test_galaxy)
         pars = {
-            "theta_int": 0.0,
-            "cosi": 1.0,
-            "x0": 0.0,
-            "y0": 0.0,
-            "g1": 0.0,
-            "g2": 0.0,
+            'theta_int': 0.0,
+            'cosi': 1.0,
+            'x0': 0.0,
+            'y0': 0.0,
+            'g1': 0.0,
+            'g2': 0.0,
         }
         config = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band="r",
+            band='r',
             use_native_orientation=False,
             pars=pars,
             use_cic_gridding=True,
@@ -117,17 +117,17 @@ class TestOrientation:
         """Test rendering at edge-on orientation."""
         gen = TNGDataVectorGenerator(test_galaxy)
         pars = {
-            "theta_int": 0.0,
-            "cosi": 0.1,
-            "x0": 0.0,
-            "y0": 0.0,
-            "g1": 0.0,
-            "g2": 0.0,
+            'theta_int': 0.0,
+            'cosi': 0.1,
+            'x0': 0.0,
+            'y0': 0.0,
+            'g1': 0.0,
+            'g2': 0.0,
         }
         config = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band="r",
+            band='r',
             use_native_orientation=False,
             pars=pars,
             use_cic_gridding=True,
@@ -145,17 +145,17 @@ class TestOrientation:
 
         # Face-on
         pars_face = {
-            "theta_int": 0.0,
-            "cosi": 1.0,
-            "x0": 0.0,
-            "y0": 0.0,
-            "g1": 0.0,
-            "g2": 0.0,
+            'theta_int': 0.0,
+            'cosi': 1.0,
+            'x0': 0.0,
+            'y0': 0.0,
+            'g1': 0.0,
+            'g2': 0.0,
         }
         config_face = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band="r",
+            band='r',
             use_native_orientation=False,
             pars=pars_face,
         )
@@ -164,17 +164,17 @@ class TestOrientation:
 
         # Edge-on
         pars_edge = {
-            "theta_int": 0.0,
-            "cosi": 0.1,
-            "x0": 0.0,
-            "y0": 0.0,
-            "g1": 0.0,
-            "g2": 0.0,
+            'theta_int': 0.0,
+            'cosi': 0.1,
+            'x0': 0.0,
+            'y0': 0.0,
+            'g1': 0.0,
+            'g2': 0.0,
         }
         config_edge = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band="r",
+            band='r',
             use_native_orientation=False,
             pars=pars_edge,
         )
@@ -185,8 +185,8 @@ class TestOrientation:
         intensity_diff = np.abs(intensity_face - intensity_edge).sum()
         velocity_diff = np.abs(velocity_face - velocity_edge).sum()
 
-        assert intensity_diff > 0, "Intensity should change with orientation"
-        assert velocity_diff > 0, "Velocity should change with orientation"
+        assert intensity_diff > 0, 'Intensity should change with orientation'
+        assert velocity_diff > 0, 'Velocity should change with orientation'
 
     def test_rotation_affects_maps(self, test_galaxy, image_pars_test):
         """Verify rotation (PA) produces different maps."""
@@ -194,17 +194,17 @@ class TestOrientation:
 
         # PA = 0
         pars_0 = {
-            "theta_int": 0.0,
-            "cosi": 0.7,
-            "x0": 0.0,
-            "y0": 0.0,
-            "g1": 0.0,
-            "g2": 0.0,
+            'theta_int': 0.0,
+            'cosi': 0.7,
+            'x0': 0.0,
+            'y0': 0.0,
+            'g1': 0.0,
+            'g2': 0.0,
         }
         config_0 = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band="r",
+            band='r',
             use_native_orientation=False,
             pars=pars_0,
         )
@@ -212,24 +212,24 @@ class TestOrientation:
 
         # PA = 90 degrees
         pars_90 = {
-            "theta_int": np.pi / 2,
-            "cosi": 0.7,
-            "x0": 0.0,
-            "y0": 0.0,
-            "g1": 0.0,
-            "g2": 0.0,
+            'theta_int': np.pi / 2,
+            'cosi': 0.7,
+            'x0': 0.0,
+            'y0': 0.0,
+            'g1': 0.0,
+            'g2': 0.0,
         }
         config_90 = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band="r",
+            band='r',
             use_native_orientation=False,
             pars=pars_90,
         )
         velocity_90, _ = gen.generate_velocity_map(config_90)
 
         velocity_diff = np.abs(velocity_0 - velocity_90).sum()
-        assert velocity_diff > 0, "Velocity should change with PA rotation"
+        assert velocity_diff > 0, 'Velocity should change with PA rotation'
 
 
 class TestGridding:
@@ -241,7 +241,7 @@ class TestGridding:
         config = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band="r",
+            band='r',
             use_cic_gridding=True,
         )
 
@@ -257,7 +257,7 @@ class TestGridding:
         config = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band="r",
+            band='r',
             use_cic_gridding=False,
         )
 
@@ -274,7 +274,7 @@ class TestGridding:
         config_cic = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band="r",
+            band='r',
             use_cic_gridding=True,
         )
         intensity_cic, _ = gen.generate_intensity_map(config_cic)
@@ -282,7 +282,7 @@ class TestGridding:
         config_ngp = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band="r",
+            band='r',
             use_cic_gridding=False,
         )
         intensity_ngp, _ = gen.generate_intensity_map(config_ngp)
@@ -292,7 +292,7 @@ class TestGridding:
         flux_diff_pct = 100 * abs(flux_cic - flux_ngp) / flux_cic
 
         # Allow 20% difference (CIC spreads to more pixels)
-        assert flux_diff_pct < 20, f"Flux conservation issue: {flux_diff_pct:.1f}%"
+        assert flux_diff_pct < 20, f'Flux conservation issue: {flux_diff_pct:.1f}%'
 
     def test_cic_smoother_than_ngp(self, test_galaxy, image_pars_test):
         """CIC should spread flux to more pixels than NGP."""
@@ -301,7 +301,7 @@ class TestGridding:
         config_cic = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band="r",
+            band='r',
             use_cic_gridding=True,
         )
         intensity_cic, _ = gen.generate_intensity_map(config_cic)
@@ -309,7 +309,7 @@ class TestGridding:
         config_ngp = TNGRenderConfig(
             target_redshift=0.6,
             image_pars=image_pars_test,
-            band="r",
+            band='r',
             use_cic_gridding=False,
         )
         intensity_ngp, _ = gen.generate_intensity_map(config_ngp)
@@ -320,7 +320,7 @@ class TestGridding:
 
         assert (
             nonzero_cic >= nonzero_ngp
-        ), "CIC should spread to at least as many pixels as NGP"
+        ), 'CIC should spread to at least as many pixels as NGP'
 
 
 class TestNoise:
@@ -330,7 +330,7 @@ class TestNoise:
         """Adding noise should increase variance."""
         gen = TNGDataVectorGenerator(test_galaxy)
         config = TNGRenderConfig(
-            target_redshift=0.6, image_pars=image_pars_test, band="r"
+            target_redshift=0.6, image_pars=image_pars_test, band='r'
         )
 
         intensity_clean, var_clean = gen.generate_intensity_map(config, snr=None)
@@ -344,7 +344,7 @@ class TestNoise:
         """Same seed should produce same noise."""
         gen = TNGDataVectorGenerator(test_galaxy)
         config = TNGRenderConfig(
-            target_redshift=0.6, image_pars=image_pars_test, band="r"
+            target_redshift=0.6, image_pars=image_pars_test, band='r'
         )
 
         intensity_1, var_1 = gen.generate_intensity_map(config, snr=50, seed=42)
@@ -359,7 +359,7 @@ class TestNoise:
         """Different seeds should produce different noise."""
         gen = TNGDataVectorGenerator(test_galaxy)
         config = TNGRenderConfig(
-            target_redshift=0.6, image_pars=image_pars_test, band="r"
+            target_redshift=0.6, image_pars=image_pars_test, band='r'
         )
 
         intensity_1, _ = gen.generate_intensity_map(config, snr=50, seed=42)
@@ -375,7 +375,7 @@ class TestParticleTypes:
         """Intensity should use stellar particles."""
         gen = TNGDataVectorGenerator(test_galaxy)
         config = TNGRenderConfig(
-            target_redshift=0.6, image_pars=image_pars_test, band="r"
+            target_redshift=0.6, image_pars=image_pars_test, band='r'
         )
 
         # Should work even without gas data
@@ -388,10 +388,10 @@ class TestParticleTypes:
 
         # Check that gas data is required
         if gen.gas is None:
-            pytest.skip("Galaxy missing gas data")
+            pytest.skip('Galaxy missing gas data')
 
         config = TNGRenderConfig(
-            target_redshift=0.6, image_pars=image_pars_test, band="r"
+            target_redshift=0.6, image_pars=image_pars_test, band='r'
         )
         velocity, _ = gen.generate_velocity_map(config)
 
@@ -402,7 +402,7 @@ class TestParticleTypes:
 class TestPhotometricBands:
     """Test different photometric bands."""
 
-    @pytest.mark.parametrize("band", ["g", "r", "i", "u", "z"])
+    @pytest.mark.parametrize('band', ['g', 'r', 'i', 'u', 'z'])
     def test_all_bands_work(self, test_galaxy, image_pars_test, band):
         """All SDSS bands should render successfully."""
         gen = TNGDataVectorGenerator(test_galaxy)
@@ -418,12 +418,12 @@ class TestPhotometricBands:
         gen = TNGDataVectorGenerator(test_galaxy)
 
         config_dusted = TNGRenderConfig(
-            target_redshift=0.6, image_pars=image_pars_test, band="r", use_dusted=True
+            target_redshift=0.6, image_pars=image_pars_test, band='r', use_dusted=True
         )
         intensity_dusted, _ = gen.generate_intensity_map(config_dusted)
 
         config_raw = TNGRenderConfig(
-            target_redshift=0.6, image_pars=image_pars_test, band="r", use_dusted=False
+            target_redshift=0.6, image_pars=image_pars_test, band='r', use_dusted=False
         )
         intensity_raw, _ = gen.generate_intensity_map(config_raw)
 
@@ -442,7 +442,7 @@ class TestEdgeCases:
 
         config = TNGRenderConfig(target_redshift=0.6, image_pars=image_pars_test)
 
-        with pytest.raises(ValueError, match="Gas data required"):
+        with pytest.raises(ValueError, match='Gas data required'):
             gen.generate_velocity_map(config)
 
     def test_pars_required_for_custom_orientation(self, test_galaxy, image_pars_test):
@@ -455,23 +455,23 @@ class TestEdgeCases:
             pars=None,  # Missing!
         )
 
-        with pytest.raises(ValueError, match="pars must be provided"):
+        with pytest.raises(ValueError, match='pars must be provided'):
             gen.generate_intensity_map(config)
 
     def test_invalid_shear_raises_error(self, test_galaxy, image_pars_test):
         """Should raise error if shear magnitude >= 1."""
-        with pytest.raises(ValueError, match="Shear too large"):
+        with pytest.raises(ValueError, match='Shear too large'):
             TNGRenderConfig(
                 target_redshift=0.6,
                 image_pars=image_pars_test,
                 use_native_orientation=False,
                 pars={
-                    "cosi": 0.7,
-                    "theta_int": 0.0,
-                    "x0": 0.0,
-                    "y0": 0.0,
-                    "g1": 0.8,
-                    "g2": 0.8,
+                    'cosi': 0.7,
+                    'theta_int': 0.0,
+                    'x0': 0.0,
+                    'y0': 0.0,
+                    'g1': 0.8,
+                    'g2': 0.8,
                 },
             )
 
@@ -492,19 +492,19 @@ class TestSFRMap:
 
         assert sfr_map.shape == image_pars_test.shape
         assert np.all(np.isfinite(sfr_map))
-        assert sfr_map.sum() > 0, "SFR map should have positive total"
-        assert np.any(sfr_map > 0), "SFR map should have some non-zero pixels"
+        assert sfr_map.sum() > 0, 'SFR map should have positive total'
+        assert np.any(sfr_map > 0), 'SFR map should have some non-zero pixels'
 
     def test_sfr_map_custom_orientation(self, test_galaxy, image_pars_test):
         """Test SFR map generation with custom orientation (uses gas offset)."""
         gen = TNGDataVectorGenerator(test_galaxy)
         pars = {
-            "theta_int": np.pi / 4,
-            "cosi": 0.7,
-            "x0": 0.0,
-            "y0": 0.0,
-            "g1": 0.0,
-            "g2": 0.0,
+            'theta_int': np.pi / 4,
+            'cosi': 0.7,
+            'x0': 0.0,
+            'y0': 0.0,
+            'g1': 0.0,
+            'g2': 0.0,
         }
         config = TNGRenderConfig(
             target_redshift=0.6,
@@ -525,12 +525,12 @@ class TestSFRMap:
 
         # Face-on
         pars_face = {
-            "theta_int": 0.0,
-            "cosi": 1.0,
-            "x0": 0.0,
-            "y0": 0.0,
-            "g1": 0.0,
-            "g2": 0.0,
+            'theta_int': 0.0,
+            'cosi': 1.0,
+            'x0': 0.0,
+            'y0': 0.0,
+            'g1': 0.0,
+            'g2': 0.0,
         }
         config_face = TNGRenderConfig(
             target_redshift=0.6,
@@ -542,12 +542,12 @@ class TestSFRMap:
 
         # Edge-on
         pars_edge = {
-            "theta_int": 0.0,
-            "cosi": 0.1,
-            "x0": 0.0,
-            "y0": 0.0,
-            "g1": 0.0,
-            "g2": 0.0,
+            'theta_int': 0.0,
+            'cosi': 0.1,
+            'x0': 0.0,
+            'y0': 0.0,
+            'g1': 0.0,
+            'g2': 0.0,
         }
         config_edge = TNGRenderConfig(
             target_redshift=0.6,
@@ -559,7 +559,7 @@ class TestSFRMap:
 
         # Maps should differ
         sfr_diff = np.abs(sfr_face - sfr_edge).sum()
-        assert sfr_diff > 0, "SFR map should change with orientation"
+        assert sfr_diff > 0, 'SFR map should change with orientation'
 
     def test_sfr_with_noise(self, test_galaxy, image_pars_test):
         """Test SFR map generation with noise."""
@@ -573,7 +573,7 @@ class TestSFRMap:
         sfr_clean = gen.generate_sfr_map(config, snr=None)
         sfr_noisy = gen.generate_sfr_map(config, snr=50, seed=42)
 
-        assert not np.allclose(sfr_clean, sfr_noisy), "Noise should change the map"
+        assert not np.allclose(sfr_clean, sfr_noisy), 'Noise should change the map'
         assert np.all(np.isfinite(sfr_noisy))
 
 
@@ -611,12 +611,12 @@ class TestTransformRoundTrip:
         native_theta_int = np.radians(gen.native_pa_deg)
 
         pars_native = {
-            "cosi": native_cosi,
-            "theta_int": native_theta_int,
-            "x0": 0.0,
-            "y0": 0.0,
-            "g1": 0.0,
-            "g2": 0.0,
+            'cosi': native_cosi,
+            'theta_int': native_theta_int,
+            'x0': 0.0,
+            'y0': 0.0,
+            'g1': 0.0,
+            'g2': 0.0,
         }
 
         config_custom = TNGRenderConfig(
@@ -630,20 +630,20 @@ class TestTransformRoundTrip:
         vel_custom, _ = gen.generate_velocity_map(config_custom, snr=None)
 
         # Both should produce valid, non-trivial maps
-        assert int_native.sum() > 0, "Native intensity should be positive"
-        assert int_custom.sum() > 0, "Custom intensity should be positive"
-        assert np.any(vel_native != 0), "Native velocity should have non-zero values"
-        assert np.any(vel_custom != 0), "Custom velocity should have non-zero values"
+        assert int_native.sum() > 0, 'Native intensity should be positive'
+        assert int_custom.sum() > 0, 'Custom intensity should be positive'
+        assert np.any(vel_native != 0), 'Native velocity should have non-zero values'
+        assert np.any(vel_custom != 0), 'Custom velocity should have non-zero values'
 
         # They may differ due to different transform paths - this is expected
         # The key is that both are internally consistent
-        print(f"✓ Native intensity sum: {int_native.sum():.2e}")
-        print(f"✓ Custom intensity sum: {int_custom.sum():.2e}")
+        print(f'✓ Native intensity sum: {int_native.sum():.2e}')
+        print(f'✓ Custom intensity sum: {int_custom.sum():.2e}')
         print(
-            f"✓ Native velocity range: [{vel_native.min():.1f}, {vel_native.max():.1f}] km/s"
+            f'✓ Native velocity range: [{vel_native.min():.1f}, {vel_native.max():.1f}] km/s'
         )
         print(
-            f"✓ Custom velocity range: [{vel_custom.min():.1f}, {vel_custom.max():.1f}] km/s"
+            f'✓ Custom velocity range: [{vel_custom.min():.1f}, {vel_custom.max():.1f}] km/s'
         )
 
     def test_orientation_sweep_consistency(self, test_galaxy, image_pars_test):
@@ -662,12 +662,12 @@ class TestTransformRoundTrip:
 
         for inc_deg in inclinations:
             pars = {
-                "cosi": np.cos(np.radians(inc_deg)),
-                "theta_int": 0.0,
-                "x0": 0.0,
-                "y0": 0.0,
-                "g1": 0.0,
-                "g2": 0.0,
+                'cosi': np.cos(np.radians(inc_deg)),
+                'theta_int': 0.0,
+                'x0': 0.0,
+                'y0': 0.0,
+                'g1': 0.0,
+                'g2': 0.0,
             }
 
             config = TNGRenderConfig(
@@ -687,28 +687,28 @@ class TestTransformRoundTrip:
         # Check that values are finite and positive
         assert all(
             np.isfinite(s) and s > 0 for s in intensity_sums
-        ), "All intensity sums should be finite and positive"
+        ), 'All intensity sums should be finite and positive'
         assert all(
             np.isfinite(r) and r > 0 for r in velocity_ranges
-        ), "All velocity ranges should be finite and positive"
+        ), 'All velocity ranges should be finite and positive'
 
         # Check for smoothness: adjacent values shouldn't differ by more than 2x
         for i in range(len(inclinations) - 1):
             int_ratio = intensity_sums[i + 1] / intensity_sums[i]
             assert (
                 0.5 < int_ratio < 2.0
-            ), f"Intensity change from inc={inclinations[i]}° to {inclinations[i + 1]}° too abrupt"
+            ), f'Intensity change from inc={inclinations[i]}° to {inclinations[i + 1]}° too abrupt'
 
             vel_ratio = velocity_ranges[i + 1] / velocity_ranges[i]
             assert (
                 0.5 < vel_ratio < 2.0
-            ), f"Velocity change from inc={inclinations[i]}° to {inclinations[i + 1]}° too abrupt"
+            ), f'Velocity change from inc={inclinations[i]}° to {inclinations[i + 1]}° too abrupt'
 
         print(
-            f"✓ Inclination sweep passed: intensity sums = {[f'{s:.2e}' for s in intensity_sums]}"
+            f'✓ Inclination sweep passed: intensity sums = {[f"{s:.2e}" for s in intensity_sums]}'
         )
         print(
-            f"✓ Inclination sweep passed: velocity ranges = {[f'{r:.1f}' for r in velocity_ranges]}"
+            f'✓ Inclination sweep passed: velocity ranges = {[f"{r:.1f}" for r in velocity_ranges]}'
         )
 
 
@@ -730,21 +730,21 @@ class TestInclinationSymmetry:
         inc_2 = 135.0  # = 180° - 45°
 
         pars_1 = {
-            "cosi": np.cos(np.radians(inc_1)),
-            "theta_int": 0.0,
-            "x0": 0.0,
-            "y0": 0.0,
-            "g1": 0.0,
-            "g2": 0.0,
+            'cosi': np.cos(np.radians(inc_1)),
+            'theta_int': 0.0,
+            'x0': 0.0,
+            'y0': 0.0,
+            'g1': 0.0,
+            'g2': 0.0,
         }
 
         pars_2 = {
-            "cosi": np.cos(np.radians(inc_2)),  # Negative cos(i)!
-            "theta_int": 0.0,
-            "x0": 0.0,
-            "y0": 0.0,
-            "g1": 0.0,
-            "g2": 0.0,
+            'cosi': np.cos(np.radians(inc_2)),  # Negative cos(i)!
+            'theta_int': 0.0,
+            'x0': 0.0,
+            'y0': 0.0,
+            'g1': 0.0,
+            'g2': 0.0,
         }
 
         config_1 = TNGRenderConfig(
@@ -773,11 +773,11 @@ class TestInclinationSymmetry:
 
         # Expect significant differences (>10 km/s somewhere in the map)
         assert max_diff > 10.0, (
-            f"TNG velocity maps at inc={inc_1}° and inc={inc_2}° "
-            f"should differ significantly, but max_diff={max_diff:.2f} km/s"
+            f'TNG velocity maps at inc={inc_1}° and inc={inc_2}° '
+            f'should differ significantly, but max_diff={max_diff:.2f} km/s'
         )
 
-        print(f"✓ TNG asymmetric: max velocity difference = {max_diff:.1f} km/s")
+        print(f'✓ TNG asymmetric: max velocity difference = {max_diff:.1f} km/s')
 
     def test_negative_cosi_handled_correctly(self, test_galaxy, image_pars_test):
         """
@@ -791,15 +791,15 @@ class TestInclinationSymmetry:
         # Test inclination >90° (cos(i) < 0)
         inc = 120.0
         cosi = np.cos(np.radians(inc))
-        assert cosi < 0, "Test requires inc > 90° so cos(i) < 0"
+        assert cosi < 0, 'Test requires inc > 90° so cos(i) < 0'
 
         pars = {
-            "cosi": cosi,
-            "theta_int": 0.0,
-            "x0": 0.0,
-            "y0": 0.0,
-            "g1": 0.0,
-            "g2": 0.0,
+            'cosi': cosi,
+            'theta_int': 0.0,
+            'x0': 0.0,
+            'y0': 0.0,
+            'g1': 0.0,
+            'g2': 0.0,
         }
 
         config = TNGRenderConfig(
@@ -815,12 +815,12 @@ class TestInclinationSymmetry:
         intensity, int_var = gen.generate_intensity_map(config, snr=50)
 
         # Maps should be valid (finite, non-zero in places)
-        assert np.all(np.isfinite(vel)), "Velocity map has non-finite values"
-        assert np.all(np.isfinite(intensity)), "Intensity map has non-finite values"
-        assert np.any(vel != 0), "Velocity map is all zeros"
-        assert np.any(intensity > 0), "Intensity map is all zeros/negative"
+        assert np.all(np.isfinite(vel)), 'Velocity map has non-finite values'
+        assert np.all(np.isfinite(intensity)), 'Intensity map has non-finite values'
+        assert np.any(vel != 0), 'Velocity map is all zeros'
+        assert np.any(intensity > 0), 'Intensity map is all zeros/negative'
 
-        print(f"✓ inc={inc}° (cos(i)={cosi:.3f}) handled correctly")
+        print(f'✓ inc={inc}° (cos(i)={cosi:.3f}) handled correctly')
 
     def test_face_on_vs_face_on_from_below(self, test_galaxy, image_pars_test):
         """
@@ -833,22 +833,22 @@ class TestInclinationSymmetry:
 
         # Face-on from above (inc=0°, cos(i)=+1)
         pars_above = {
-            "cosi": 1.0,
-            "theta_int": 0.0,
-            "x0": 0.0,
-            "y0": 0.0,
-            "g1": 0.0,
-            "g2": 0.0,
+            'cosi': 1.0,
+            'theta_int': 0.0,
+            'x0': 0.0,
+            'y0': 0.0,
+            'g1': 0.0,
+            'g2': 0.0,
         }
 
         # Face-on from below (inc=180°, cos(i)=-1)
         pars_below = {
-            "cosi": -1.0,
-            "theta_int": 0.0,
-            "x0": 0.0,
-            "y0": 0.0,
-            "g1": 0.0,
-            "g2": 0.0,
+            'cosi': -1.0,
+            'theta_int': 0.0,
+            'x0': 0.0,
+            'y0': 0.0,
+            'g1': 0.0,
+            'g2': 0.0,
         }
 
         config_above = TNGRenderConfig(
@@ -877,8 +877,8 @@ class TestInclinationSymmetry:
         vel_diff = np.abs(vel_above - vel_below)
         vel_max_diff = np.nanmax(vel_diff)
         assert vel_max_diff > 5.0, (
-            f"Face-on velocities from above/below should differ, "
-            f"but max_diff={vel_max_diff:.2f} km/s"
+            f'Face-on velocities from above/below should differ, '
+            f'but max_diff={vel_max_diff:.2f} km/s'
         )
 
         # Intensity: should be similar (same particles, same projection)
@@ -886,12 +886,12 @@ class TestInclinationSymmetry:
         int_rel_diff = np.abs(int_above - int_below) / (int_above + int_below + 1e-10)
         int_median_rel_diff = np.nanmedian(int_rel_diff[int_rel_diff > 0])
         assert int_median_rel_diff < 0.5, (
-            f"Face-on intensity from above/below should be similar, "
-            f"but median_rel_diff={int_median_rel_diff:.2f}"
+            f'Face-on intensity from above/below should be similar, '
+            f'but median_rel_diff={int_median_rel_diff:.2f}'
         )
 
-        print(f"✓ Face-on velocity diff = {vel_max_diff:.1f} km/s")
-        print(f"✓ Face-on intensity median_rel_diff = {int_median_rel_diff:.3f}")
+        print(f'✓ Face-on velocity diff = {vel_max_diff:.1f} km/s')
+        print(f'✓ Face-on intensity median_rel_diff = {int_median_rel_diff:.3f}')
 
 
 class TestDustAttenuation:
@@ -902,18 +902,18 @@ class TestDustAttenuation:
         gen = TNGDataVectorGenerator(test_galaxy)
 
         config_dusted = TNGRenderConfig(
-            target_redshift=0.6, image_pars=image_pars_test, band="r", use_dusted=True
+            target_redshift=0.6, image_pars=image_pars_test, band='r', use_dusted=True
         )
         intensity_dusted, _ = gen.generate_intensity_map(config_dusted)
 
         config_raw = TNGRenderConfig(
-            target_redshift=0.6, image_pars=image_pars_test, band="r", use_dusted=False
+            target_redshift=0.6, image_pars=image_pars_test, band='r', use_dusted=False
         )
         intensity_raw, _ = gen.generate_intensity_map(config_raw)
 
         assert (
             intensity_raw.sum() > intensity_dusted.sum()
-        ), "Dust should attenuate flux"
+        ), 'Dust should attenuate flux'
 
     def test_dust_attenuation_model(self, test_galaxy):
         gen = TNGDataVectorGenerator(test_galaxy)
@@ -922,23 +922,23 @@ class TestDustAttenuation:
         # The two should give consistent results since they have the same dust attenuation model.
 
         # Assuming using catalogues that fixed the line-of-sight to be along the z-axis.
-        coords_stellar_2d = gen.stellar["Coordinates"][:, :2]  # x,y positions
-        coords_gas_2d = gen.gas["Coordinates"][:, :2]
-        coords_galaxy_center_2d = gen.subhalo["SubhaloPos"][:2]  # x,y of galaxy center
+        coords_stellar_2d = gen.stellar['Coordinates'][:, :2]  # x,y positions
+        coords_gas_2d = gen.gas['Coordinates'][:, :2]
+        coords_galaxy_center_2d = gen.subhalo['SubhaloPos'][:2]  # x,y of galaxy center
 
         # Using the native orientation to compute the dust attenuation and compare to the TNG data.
         gen._estimate_magnitude_luminosity(
-            coords_stellar_2d, coords_gas_2d, coords_galaxy_center_2d, band="r"
+            coords_stellar_2d, coords_gas_2d, coords_galaxy_center_2d, band='r'
         )
 
         assert np.allclose(
-            gen.stellar["Dusted_Luminosity_rotate_r"],
-            gen.stellar["Dusted_Luminosity_r"],
-        ), "Stellar luminosity after dust attenuation correction should match TNG data"
+            gen.stellar['Dusted_Luminosity_rotate_r'],
+            gen.stellar['Dusted_Luminosity_r'],
+        ), 'Stellar luminosity after dust attenuation correction should match TNG data'
         assert np.allclose(
-            gen.stellar["Dusted_Absolute_Magnitude_rotate_r"],
-            gen.stellar["Dusted_Absolute_Magnitude_r"],
-        ), "Stellar absolute magnitude after dust attenuation correction should match TNG data"
+            gen.stellar['Dusted_Absolute_Magnitude_rotate_r'],
+            gen.stellar['Dusted_Absolute_Magnitude_r'],
+        ), 'Stellar absolute magnitude after dust attenuation correction should match TNG data'
 
 
 @pytest.mark.tng_diagnostics
@@ -949,10 +949,10 @@ class TestDiagnosticPlots:
     from unit tests as they are slower and generate large plot files.
     """
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture(scope='class')
     def output_dir(self):
         """Create output directory for diagnostic plots."""
-        out_dir = Path(__file__).parent / "out" / "tng_diagnostics"
+        out_dir = Path(__file__).parent / 'out' / 'tng_diagnostics'
         out_dir.mkdir(parents=True, exist_ok=True)
         return out_dir
 
@@ -1027,12 +1027,12 @@ class TestDiagnosticPlots:
         from mpl_toolkits.axes_grid1 import make_axes_locatable
 
         divider = make_axes_locatable(ax)
-        cax = divider.append_axes("right", size="5%", pad=0.05)
+        cax = divider.append_axes('right', size='5%', pad=0.05)
         return plt.colorbar(im, cax=cax, **kwargs)
 
     @staticmethod
     def add_scale_markers(
-        ax, image_pars, scale_bar_arcsec=1.0, color="black", crosshair_arcsec=0.3
+        ax, image_pars, scale_bar_arcsec=1.0, color='black', crosshair_arcsec=0.3
     ):
         """
         Add physical scale bar and center marker to a plot.
@@ -1074,20 +1074,20 @@ class TestDiagnosticPlots:
                 [y_start, y_start],
                 color=color,
                 linewidth=3,
-                solid_capstyle="butt",
+                solid_capstyle='butt',
             )
             ax.text(
                 x_start + scale_bar_pixels / 2,
                 y_start + 0.04 * image_pars.shape[0],
                 f'{scale_bar_arcsec}"',
                 color=color,
-                ha="center",
-                va="bottom",
+                ha='center',
+                va='bottom',
                 fontsize=8,
-                weight="bold",
+                weight='bold',
                 bbox=dict(
-                    boxstyle="round,pad=0.3",
-                    facecolor="white" if color == "black" else "black",
+                    boxstyle='round,pad=0.3',
+                    facecolor='white' if color == 'black' else 'black',
                     alpha=0.7,
                     edgecolor=color,
                 ),
@@ -1099,18 +1099,18 @@ class TestDiagnosticPlots:
             ax.plot(
                 [cx - marker_size_pix, cx + marker_size_pix],
                 [cy, cy],
-                "k-",
+                'k-',
                 linewidth=0.8,
                 alpha=0.6,
             )
             ax.plot(
                 [cx, cx],
                 [cy - marker_size_pix, cy + marker_size_pix],
-                "k-",
+                'k-',
                 linewidth=0.8,
                 alpha=0.6,
             )
-            ax.plot(cx, cy, "k+", markersize=6, markeredgewidth=1, alpha=0.6)
+            ax.plot(cx, cy, 'k+', markersize=6, markeredgewidth=1, alpha=0.6)
         else:
             # Data coordinate system (arcsec)
             fov_x = image_pars.shape[1] * image_pars.pixel_scale
@@ -1123,20 +1123,20 @@ class TestDiagnosticPlots:
                 [y_start, y_start],
                 color=color,
                 linewidth=3,
-                solid_capstyle="butt",
+                solid_capstyle='butt',
             )
             ax.text(
                 x_start + scale_bar_arcsec / 2,
                 y_start + 0.04 * fov_y,
                 f'{scale_bar_arcsec}"',
                 color=color,
-                ha="center",
-                va="bottom",
+                ha='center',
+                va='bottom',
                 fontsize=8,
-                weight="bold",
+                weight='bold',
                 bbox=dict(
-                    boxstyle="round,pad=0.3",
-                    facecolor="white" if color == "black" else "black",
+                    boxstyle='round,pad=0.3',
+                    facecolor='white' if color == 'black' else 'black',
                     alpha=0.7,
                     edgecolor=color,
                 ),
@@ -1146,18 +1146,18 @@ class TestDiagnosticPlots:
             ax.plot(
                 [-crosshair_arcsec, crosshair_arcsec],
                 [0, 0],
-                "k-",
+                'k-',
                 linewidth=0.8,
                 alpha=0.6,
             )
             ax.plot(
                 [0, 0],
                 [-crosshair_arcsec, crosshair_arcsec],
-                "k-",
+                'k-',
                 linewidth=0.8,
                 alpha=0.6,
             )
-            ax.plot(0, 0, "k+", markersize=6, markeredgewidth=1, alpha=0.6)
+            ax.plot(0, 0, 'k+', markersize=6, markeredgewidth=1, alpha=0.6)
 
     def test_all_galaxies_high_res_native(self, tng_data, output_dir):
         """
@@ -1175,7 +1175,7 @@ class TestDiagnosticPlots:
 
         n_galaxies = len(tng_data)
         image_pars = ImagePars(
-            shape=(128, 128), pixel_scale=0.05, indexing="ij"
+            shape=(128, 128), pixel_scale=0.05, indexing='ij'
         )  # High res
         target_z = 0.7
         native_z = 0.011
@@ -1189,7 +1189,7 @@ class TestDiagnosticPlots:
             gen = TNGDataVectorGenerator(galaxy)
 
             # Get metadata
-            subhalo_id = int(galaxy["subhalo"]["SubhaloID"])
+            subhalo_id = int(galaxy['subhalo']['SubhaloID'])
             inc_deg = gen.native_inclination_deg
             pa_deg = gen.native_pa_deg
             flipped = gen.flipped_from_below
@@ -1215,36 +1215,36 @@ class TestDiagnosticPlots:
             vmin, vmax = self.compute_robust_intensity_bounds(int_log, log=True)
             im_int = ax_int.imshow(
                 int_log,
-                origin="lower",
-                cmap="viridis",
-                aspect="equal",
+                origin='lower',
+                cmap='viridis',
+                aspect='equal',
                 vmin=vmin,
                 vmax=vmax,
             )
-            ax_int.set_title(f"Intensity - Galaxy {idx} (ID={subhalo_id})", fontsize=10)
+            ax_int.set_title(f'Intensity - Galaxy {idx} (ID={subhalo_id})', fontsize=10)
             # Remove axis ticks and labels for cleaner appearance
             ax_int.set_xticks([])
             ax_int.set_yticks([])
             plt.colorbar(
-                im_int, ax=ax_int, label="log$_{10}$(Flux)", fraction=0.046, pad=0.02
+                im_int, ax=ax_int, label='log$_{10}$(Flux)', fraction=0.046, pad=0.02
             )
 
             # Add metadata text
-            flipped_str = " (flipped)" if flipped else ""
+            flipped_str = ' (flipped)' if flipped else ''
             ax_int.text(
                 0.02,
                 0.98,
-                f"inc={inc_deg:.1f}°{flipped_str}\nPA={pa_deg:.1f}°",
+                f'inc={inc_deg:.1f}°{flipped_str}\nPA={pa_deg:.1f}°',
                 transform=ax_int.transAxes,
-                va="top",
-                ha="left",
-                bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
+                va='top',
+                ha='left',
+                bbox=dict(boxstyle='round', facecolor='white', alpha=0.8),
                 fontsize=8,
             )
 
             # Add scale bar and center marker (white for intensity)
             self.add_scale_markers(
-                ax_int, image_pars, scale_bar_arcsec=1.0, color="white"
+                ax_int, image_pars, scale_bar_arcsec=1.0, color='white'
             )
 
             # Plot velocity with diverging colormap (white=0)
@@ -1252,19 +1252,19 @@ class TestDiagnosticPlots:
             vmax = np.nanmax(np.abs(velocity))
             im_vel = ax_vel.imshow(
                 velocity,
-                origin="lower",
-                cmap="RdBu_r",
-                aspect="equal",
+                origin='lower',
+                cmap='RdBu_r',
+                aspect='equal',
                 norm=MidpointNormalize(vmin=-vmax, vmax=vmax, midpoint=0),
             )
-            ax_vel.set_title(f"Velocity - Galaxy {idx} (ID={subhalo_id})", fontsize=10)
+            ax_vel.set_title(f'Velocity - Galaxy {idx} (ID={subhalo_id})', fontsize=10)
             # Remove axis ticks and labels for cleaner appearance
             ax_vel.set_xticks([])
             ax_vel.set_yticks([])
             plt.colorbar(
                 im_vel,
                 ax=ax_vel,
-                label=r"$v_\mathrm{LOS}$ [km/s]",
+                label=r'$v_\mathrm{LOS}$ [km/s]',
                 fraction=0.046,
                 pad=0.02,
             )
@@ -1273,24 +1273,24 @@ class TestDiagnosticPlots:
             self.add_scale_markers(ax_vel, image_pars, scale_bar_arcsec=1.0)
 
             print(
-                f"✓ Galaxy {idx} (SubhaloID={subhalo_id}): "
-                f"inc={inc_deg:.1f}°, PA={pa_deg:.1f}°, flipped={flipped}"
+                f'✓ Galaxy {idx} (SubhaloID={subhalo_id}): '
+                f'inc={inc_deg:.1f}°, PA={pa_deg:.1f}°, flipped={flipped}'
             )
 
         # Leave room at top for suptitle (top=0.96 leaves ~4% for title)
         gs.update(top=0.96, bottom=0.01)
         fig.suptitle(
-            f"TNG50 Galaxies - Native Orientation (z={native_z:.3f}→{target_z:.1f})",
+            f'TNG50 Galaxies - Native Orientation (z={native_z:.3f}→{target_z:.1f})',
             fontsize=14,
             y=0.99,
         )
         plt.savefig(
-            output_dir / "all_galaxies_native_highres.png", dpi=150, bbox_inches="tight"
+            output_dir / 'all_galaxies_native_highres.png', dpi=150, bbox_inches='tight'
         )
         plt.close()
 
         print(
-            f"✓ Saved diagnostic plot: {output_dir / 'all_galaxies_native_highres.png'}"
+            f'✓ Saved diagnostic plot: {output_dir / "all_galaxies_native_highres.png"}'
         )
 
     def test_cic_vs_ngp_comparison(self, test_galaxy, output_dir):
@@ -1311,7 +1311,7 @@ class TestDiagnosticPlots:
         from kl_pipe.tng.data_vectors import convert_tng_to_arcsec
 
         gen = TNGDataVectorGenerator(test_galaxy)
-        image_pars = ImagePars(shape=(64, 64), pixel_scale=0.1, indexing="ij")
+        image_pars = ImagePars(shape=(64, 64), pixel_scale=0.1, indexing='ij')
         target_z = 0.7
         fov_arcsec = image_pars.shape[0] * image_pars.pixel_scale  # Same for both dims
 
@@ -1337,7 +1337,7 @@ class TestDiagnosticPlots:
 
         # Get particle positions for scatter plots
         # Stellar particles (for intensity)
-        stellar_coords = gen.stellar["Coordinates"].copy()
+        stellar_coords = gen.stellar['Coordinates'].copy()
         stellar_center = gen._get_reference_center(
             config_cic.center_on_peak, config_cic.band, config_cic.use_dusted
         )
@@ -1357,7 +1357,7 @@ class TestDiagnosticPlots:
         stellar_lum_log = np.log10(stellar_lum + 1e-10)
 
         # Gas particles (for velocity)
-        gas_coords = gen.gas["Coordinates"].copy()
+        gas_coords = gen.gas['Coordinates'].copy()
         gas_center = stellar_center  # Use same center for consistency
         gas_coords_centered = gen._center_coordinates(gas_coords, gas_center)
         gas_coords_2d = gas_coords_centered[:, :2]  # Just drop z for native orientation
@@ -1367,7 +1367,7 @@ class TestDiagnosticPlots:
 
         # Gas velocities - must subtract systemic velocity like the gridded maps do
         # The generate_velocity_map method subtracts median velocity to center at v=0
-        gas_vel_3d = gen.gas["Velocities"].copy()
+        gas_vel_3d = gen.gas['Velocities'].copy()
         v_systemic = np.median(gas_vel_3d, axis=0)
         gas_vel_3d -= v_systemic  # Now in galaxy rest frame
         # For native orientation, LOS is along z-axis, so v_LOS = v_z
@@ -1398,15 +1398,15 @@ class TestDiagnosticPlots:
             c=lum_p,
             s=1,
             alpha=0.5,
-            cmap="viridis",
+            cmap='viridis',
             vmin=vmin_lum,
             vmax=vmax_lum,
         )
         ax.set_xlim(-fov_arcsec / 2, fov_arcsec / 2)
         ax.set_ylim(-fov_arcsec / 2, fov_arcsec / 2)
-        ax.set_aspect("equal")
-        ax.set_title("Particles (Stellar)", fontsize=11)
-        self.add_colorbar_matching_height(sc_int, ax, label="log$_{10}$(Lum)")
+        ax.set_aspect('equal')
+        ax.set_title('Particles (Stellar)', fontsize=11)
+        self.add_colorbar_matching_height(sc_int, ax, label='log$_{10}$(Lum)')
 
         # Column 1: CIC
         ax = axes[0, 1]
@@ -1414,34 +1414,34 @@ class TestDiagnosticPlots:
         vmin, vmax = self.compute_robust_intensity_bounds(int_log_cic, log=True)
         im = ax.imshow(
             int_log_cic,
-            origin="lower",
-            cmap="viridis",
-            aspect="equal",
+            origin='lower',
+            cmap='viridis',
+            aspect='equal',
             vmin=vmin,
             vmax=vmax,
         )
-        ax.set_title("CIC Gridded\n(Cloud-in-Cell)", fontsize=10)
+        ax.set_title('CIC Gridded\n(Cloud-in-Cell)', fontsize=10)
         ax.set_xticks([])
         ax.set_yticks([])
-        self.add_colorbar_matching_height(im, ax, label="log$_{10}$(Flux)")
-        self.add_scale_markers(ax, image_pars, scale_bar_arcsec=1.0, color="white")
+        self.add_colorbar_matching_height(im, ax, label='log$_{10}$(Flux)')
+        self.add_scale_markers(ax, image_pars, scale_bar_arcsec=1.0, color='white')
 
         # Column 2: NGP
         ax = axes[0, 2]
         int_log_ngp = np.log10(int_ngp + 1e-10)
         im = ax.imshow(
             int_log_ngp,
-            origin="lower",
-            cmap="viridis",
-            aspect="equal",
+            origin='lower',
+            cmap='viridis',
+            aspect='equal',
             vmin=vmin,
             vmax=vmax,
         )
-        ax.set_title("NGP Gridded\n(Nearest-Grid-Point)", fontsize=10)
+        ax.set_title('NGP Gridded\n(Nearest-Grid-Point)', fontsize=10)
         ax.set_xticks([])
         ax.set_yticks([])
-        self.add_colorbar_matching_height(im, ax, label="log$_{10}$(Flux)")
-        self.add_scale_markers(ax, image_pars, scale_bar_arcsec=1.0, color="white")
+        self.add_colorbar_matching_height(im, ax, label='log$_{10}$(Flux)')
+        self.add_scale_markers(ax, image_pars, scale_bar_arcsec=1.0, color='white')
 
         # Column 3: Residuals (CIC - NGP)
         ax = axes[0, 3]
@@ -1449,16 +1449,16 @@ class TestDiagnosticPlots:
         resid_max = np.percentile(np.abs(int_resid), 99)
         im = ax.imshow(
             int_resid,
-            origin="lower",
-            cmap="RdBu_r",
-            aspect="equal",
+            origin='lower',
+            cmap='RdBu_r',
+            aspect='equal',
             vmin=-resid_max,
             vmax=resid_max,
         )
-        ax.set_title("Residual (CIC - NGP)", fontsize=11)
+        ax.set_title('Residual (CIC - NGP)', fontsize=11)
         ax.set_xticks([])
         ax.set_yticks([])
-        self.add_colorbar_matching_height(im, ax, label="ΔFlux")
+        self.add_colorbar_matching_height(im, ax, label='ΔFlux')
 
         # === Row 1: Velocity ===
         # Column 0: Particle scatter
@@ -1481,45 +1481,45 @@ class TestDiagnosticPlots:
             c=vel_g,
             s=1,
             alpha=0.5,
-            cmap="RdBu_r",
+            cmap='RdBu_r',
             vmin=-vel_max_gridded,
             vmax=vel_max_gridded,
         )
         ax.set_xlim(-fov_arcsec / 2, fov_arcsec / 2)
         ax.set_ylim(-fov_arcsec / 2, fov_arcsec / 2)
-        ax.set_aspect("equal")
-        ax.set_title("Particles (Gas)", fontsize=11)
-        self.add_colorbar_matching_height(sc_vel, ax, label="v$_z$ [km/s]")
+        ax.set_aspect('equal')
+        ax.set_title('Particles (Gas)', fontsize=11)
+        self.add_colorbar_matching_height(sc_vel, ax, label='v$_z$ [km/s]')
 
         # Column 1: Velocity CIC
         ax = axes[1, 1]
         vel_max = max(np.nanmax(np.abs(vel_cic)), np.nanmax(np.abs(vel_ngp)))
         im = ax.imshow(
             vel_cic,
-            origin="lower",
-            cmap="RdBu_r",
-            aspect="equal",
+            origin='lower',
+            cmap='RdBu_r',
+            aspect='equal',
             norm=MidpointNormalize(vmin=-vel_max, vmax=vel_max, midpoint=0),
         )
-        ax.set_title("CIC Gridded\n(Cloud-in-Cell)", fontsize=10)
+        ax.set_title('CIC Gridded\n(Cloud-in-Cell)', fontsize=10)
         ax.set_xticks([])
         ax.set_yticks([])
-        self.add_colorbar_matching_height(im, ax, label="v$_{\\rm LOS}$ [km/s]")
+        self.add_colorbar_matching_height(im, ax, label='v$_{\\rm LOS}$ [km/s]')
         self.add_scale_markers(ax, image_pars, scale_bar_arcsec=1.0)
 
         # Column 2: Velocity NGP
         ax = axes[1, 2]
         im = ax.imshow(
             vel_ngp,
-            origin="lower",
-            cmap="RdBu_r",
-            aspect="equal",
+            origin='lower',
+            cmap='RdBu_r',
+            aspect='equal',
             norm=MidpointNormalize(vmin=-vel_max, vmax=vel_max, midpoint=0),
         )
-        ax.set_title("NGP Gridded\n(Nearest-Grid-Point)", fontsize=10)
+        ax.set_title('NGP Gridded\n(Nearest-Grid-Point)', fontsize=10)
         ax.set_xticks([])
         ax.set_yticks([])
-        self.add_colorbar_matching_height(im, ax, label="v$_{\\rm LOS}$ [km/s]")
+        self.add_colorbar_matching_height(im, ax, label='v$_{\\rm LOS}$ [km/s]')
         self.add_scale_markers(ax, image_pars, scale_bar_arcsec=1.0)
 
         # Column 3: Velocity Residuals
@@ -1533,29 +1533,29 @@ class TestDiagnosticPlots:
             vel_resid_max = 1.0
         im = ax.imshow(
             vel_resid,
-            origin="lower",
-            cmap="RdBu_r",
-            aspect="equal",
+            origin='lower',
+            cmap='RdBu_r',
+            aspect='equal',
             vmin=-vel_resid_max,
             vmax=vel_resid_max,
         )
-        ax.set_title("Residual (CIC - NGP)", fontsize=11)
+        ax.set_title('Residual (CIC - NGP)', fontsize=11)
         ax.set_xticks([])
         ax.set_yticks([])
-        self.add_colorbar_matching_height(im, ax, label="Δv [km/s]")
+        self.add_colorbar_matching_height(im, ax, label='Δv [km/s]')
 
         fig.suptitle(
-            f"Gridding Comparison: Particles → CIC → NGP → Residuals (z=0.011→{target_z})",
+            f'Gridding Comparison: Particles → CIC → NGP → Residuals (z=0.011→{target_z})',
             fontsize=13,
         )
         plt.tight_layout()
         plt.savefig(
-            output_dir / "cic_vs_ngp_comparison.png", dpi=150, bbox_inches="tight"
+            output_dir / 'cic_vs_ngp_comparison.png', dpi=150, bbox_inches='tight'
         )
         plt.close()
 
         print(
-            f"✓ Saved CIC vs NGP comparison: {output_dir / 'cic_vs_ngp_comparison.png'}"
+            f'✓ Saved CIC vs NGP comparison: {output_dir / "cic_vs_ngp_comparison.png"}'
         )
 
     def test_symmetry_breaking_inclinations(self, test_galaxy, output_dir):
@@ -1569,7 +1569,7 @@ class TestDiagnosticPlots:
         import matplotlib.pyplot as plt
 
         gen = TNGDataVectorGenerator(test_galaxy)
-        image_pars = ImagePars(shape=(64, 64), pixel_scale=0.1, indexing="ij")
+        image_pars = ImagePars(shape=(64, 64), pixel_scale=0.1, indexing='ij')
         target_z = 0.7
 
         inc_1 = 45.0  # Viewing from above at 45° tilt
@@ -1577,12 +1577,12 @@ class TestDiagnosticPlots:
 
         # First inclination
         pars_1 = {
-            "cosi": np.cos(np.radians(inc_1)),
-            "theta_int": 0.0,
-            "x0": 0.0,
-            "y0": 0.0,
-            "g1": 0.0,
-            "g2": 0.0,
+            'cosi': np.cos(np.radians(inc_1)),
+            'theta_int': 0.0,
+            'x0': 0.0,
+            'y0': 0.0,
+            'g1': 0.0,
+            'g2': 0.0,
         }
         config_1 = TNGRenderConfig(
             target_redshift=target_z,
@@ -1596,12 +1596,12 @@ class TestDiagnosticPlots:
 
         # Second inclination
         pars_2 = {
-            "cosi": np.cos(np.radians(inc_2)),
-            "theta_int": 0.0,
-            "x0": 0.0,
-            "y0": 0.0,
-            "g1": 0.0,
-            "g2": 0.0,
+            'cosi': np.cos(np.radians(inc_2)),
+            'theta_int': 0.0,
+            'x0': 0.0,
+            'y0': 0.0,
+            'g1': 0.0,
+            'g2': 0.0,
         }
         config_2 = TNGRenderConfig(
             target_redshift=target_z,
@@ -1637,55 +1637,55 @@ class TestDiagnosticPlots:
         # Row 1: inc=45°
         im00 = axes[0, 0].imshow(
             int_log_1,
-            origin="lower",
-            cmap="viridis",
-            aspect="equal",
+            origin='lower',
+            cmap='viridis',
+            aspect='equal',
             vmin=vmin,
             vmax=vmax,
         )
-        axes[0, 0].set_title(f"Intensity - inc={inc_1}° (from above)", fontsize=11)
-        plt.colorbar(im00, ax=axes[0, 0], label="log$_{10}$(Flux)")
+        axes[0, 0].set_title(f'Intensity - inc={inc_1}° (from above)', fontsize=11)
+        plt.colorbar(im00, ax=axes[0, 0], label='log$_{10}$(Flux)')
         self.add_scale_markers(
-            axes[0, 0], image_pars, scale_bar_arcsec=1.0, color="white"
+            axes[0, 0], image_pars, scale_bar_arcsec=1.0, color='white'
         )
 
         vmax_1 = np.nanmax(np.abs(vel_1))
         im01 = axes[0, 1].imshow(
             vel_1,
-            origin="lower",
-            cmap="RdBu_r",
-            aspect="equal",
+            origin='lower',
+            cmap='RdBu_r',
+            aspect='equal',
             norm=MidpointNormalize(vmin=-vmax_1, vmax=vmax_1, midpoint=0),
         )
-        axes[0, 1].set_title(f"Velocity - inc={inc_1}° (from above)", fontsize=11)
-        plt.colorbar(im01, ax=axes[0, 1], label="v_LOS [km/s]")
+        axes[0, 1].set_title(f'Velocity - inc={inc_1}° (from above)', fontsize=11)
+        plt.colorbar(im01, ax=axes[0, 1], label='v_LOS [km/s]')
         self.add_scale_markers(axes[0, 1], image_pars, scale_bar_arcsec=1.0)
 
         # Row 2: inc=135°
         im10 = axes[1, 0].imshow(
             int_log_2,
-            origin="lower",
-            cmap="viridis",
-            aspect="equal",
+            origin='lower',
+            cmap='viridis',
+            aspect='equal',
             vmin=vmin,
             vmax=vmax,
         )
-        axes[1, 0].set_title(f"Intensity - inc={inc_2}° (from below)", fontsize=11)
-        plt.colorbar(im10, ax=axes[1, 0], label="log$_{10}$(Flux)")
+        axes[1, 0].set_title(f'Intensity - inc={inc_2}° (from below)', fontsize=11)
+        plt.colorbar(im10, ax=axes[1, 0], label='log$_{10}$(Flux)')
         self.add_scale_markers(
-            axes[1, 0], image_pars, scale_bar_arcsec=1.0, color="white"
+            axes[1, 0], image_pars, scale_bar_arcsec=1.0, color='white'
         )
 
         vmax_2 = np.nanmax(np.abs(vel_2))
         im11 = axes[1, 1].imshow(
             vel_2,
-            origin="lower",
-            cmap="RdBu_r",
-            aspect="equal",
+            origin='lower',
+            cmap='RdBu_r',
+            aspect='equal',
             norm=MidpointNormalize(vmin=-vmax_2, vmax=vmax_2, midpoint=0),
         )
-        axes[1, 1].set_title(f"Velocity - inc={inc_2}°")
-        plt.colorbar(im11, ax=axes[1, 1], label="v_LOS [km/s]")
+        axes[1, 1].set_title(f'Velocity - inc={inc_2}°')
+        plt.colorbar(im11, ax=axes[1, 1], label='v_LOS [km/s]')
 
         # Row 3: Differences
         # Use arcsinh scaling for intensity difference to see small features
@@ -1693,43 +1693,43 @@ class TestDiagnosticPlots:
         diff_max = np.nanmax(np.abs(int_diff_scaled))
         im20 = axes[2, 0].imshow(
             int_diff_scaled,
-            origin="lower",
-            cmap="RdBu_r",
+            origin='lower',
+            cmap='RdBu_r',
             vmin=-diff_max,
             vmax=diff_max,
         )
-        axes[2, 0].set_title("Intensity Difference (arcsinh scaled)", fontsize=11)
-        plt.colorbar(im20, ax=axes[2, 0], label="arcsinh(ΔFlux)")
+        axes[2, 0].set_title('Intensity Difference (arcsinh scaled)', fontsize=11)
+        plt.colorbar(im20, ax=axes[2, 0], label='arcsinh(ΔFlux)')
 
         vel_diff_max = np.nanmax(np.abs(vel_diff))
         im21 = axes[2, 1].imshow(
             vel_diff,
-            origin="lower",
-            cmap="RdBu_r",
+            origin='lower',
+            cmap='RdBu_r',
             vmin=-vel_diff_max,
             vmax=vel_diff_max,
         )
-        axes[2, 1].set_title(f"Velocity Difference")
-        plt.colorbar(im21, ax=axes[2, 1], label="Δv_LOS [km/s]")
+        axes[2, 1].set_title(f'Velocity Difference')
+        plt.colorbar(im21, ax=axes[2, 1], label='Δv_LOS [km/s]')
 
         fig.suptitle(
-            f"TNG Asymmetry: inc={inc_1}° vs inc={inc_2}°\n"
-            f"(Symmetric models would show zero difference)",
+            f'TNG Asymmetry: inc={inc_1}° vs inc={inc_2}°\n'
+            f'(Symmetric models would show zero difference)',
             fontsize=14,
         )
         plt.tight_layout()
         plt.savefig(
-            output_dir / "symmetry_breaking_inclinations.png",
+            output_dir / 'symmetry_breaking_inclinations.png',
             dpi=150,
-            bbox_inches="tight",
+            bbox_inches='tight',
         )
         plt.close()
 
         max_vel_diff = np.nanmax(np.abs(vel_diff))
         print(
-            f"✓ Max velocity difference: {max_vel_diff:.1f} km/s (confirms asymmetry)"
+            f'✓ Max velocity difference: {max_vel_diff:.1f} km/s (confirms asymmetry)'
         )
-        print(f"✓ Saved: {output_dir / 'symmetry_breaking_inclinations.png'}")
+        print(f'✓ Saved: {output_dir / "symmetry_breaking_inclinations.png"}')
 
     def test_resolution_and_snr_grid(self, test_galaxy, output_dir):
         """
@@ -1760,7 +1760,7 @@ class TestDiagnosticPlots:
         for i, pix_scale in enumerate(pixel_scales):
             npix = int(np.round(fov_arcsec / pix_scale))
             shape = (npix, npix)
-            image_pars = ImagePars(shape=shape, pixel_scale=pix_scale, indexing="ij")
+            image_pars = ImagePars(shape=shape, pixel_scale=pix_scale, indexing='ij')
 
             for j, snr in enumerate(snr_levels):
                 config = TNGRenderConfig(
@@ -1794,45 +1794,45 @@ class TestDiagnosticPlots:
                 int_log = np.log10(np.clip(intensity, 1e-10, None))
                 im_int = ax_int.imshow(
                     int_log,
-                    origin="lower",
-                    cmap="viridis",
-                    aspect="equal",
+                    origin='lower',
+                    cmap='viridis',
+                    aspect='equal',
                     vmin=vmin_int_global,
                     vmax=vmax_int_global,
                 )
 
-                snr_str = f"SNR={snr}" if snr is not None else "No noise"
+                snr_str = f'SNR={snr}' if snr is not None else 'No noise'
                 if i == 0:  # Top row
-                    ax_int.set_title(f"{snr_str}", fontsize=10)
+                    ax_int.set_title(f'{snr_str}', fontsize=10)
                 ax_int.set_xticks([])
                 ax_int.set_yticks([])
                 if j == 0:  # Left column
-                    ax_int.set_ylabel(f'{pix_scale}"/pix', fontsize=9, weight="bold")
+                    ax_int.set_ylabel(f'{pix_scale}"/pix', fontsize=9, weight='bold')
 
                 # Add colorbar
                 plt.colorbar(im_int, ax=ax_int, fraction=0.046, pad=0.04)
 
                 # Add scale markers (white for intensity)
                 self.add_scale_markers(
-                    ax_int, image_pars, scale_bar_arcsec=1.0, color="white"
+                    ax_int, image_pars, scale_bar_arcsec=1.0, color='white'
                 )
 
                 # VELOCITY (bottom 3 rows) - RdBu_r with white=0, global bounds
                 ax_vel = axes[i + 3, j]
                 im_vel = ax_vel.imshow(
                     velocity,
-                    origin="lower",
-                    cmap="RdBu_r",
+                    origin='lower',
+                    cmap='RdBu_r',
                     norm=MidpointNormalize(
                         vmin=-vmax_vel_global, vmax=vmax_vel_global, midpoint=0
                     ),
-                    aspect="equal",
+                    aspect='equal',
                 )
 
                 ax_vel.set_xticks([])
                 ax_vel.set_yticks([])
                 if j == 0:  # Left column
-                    ax_vel.set_ylabel(f'{pix_scale}"/pix', fontsize=9, weight="bold")
+                    ax_vel.set_ylabel(f'{pix_scale}"/pix', fontsize=9, weight='bold')
 
                 # Add colorbar
                 plt.colorbar(im_vel, ax=ax_vel, fraction=0.046, pad=0.04)
@@ -1844,14 +1844,14 @@ class TestDiagnosticPlots:
         fig.text(
             0.02,
             0.75,
-            "INTENSITY",
+            'INTENSITY',
             rotation=90,
-            va="center",
+            va='center',
             fontsize=12,
-            weight="bold",
+            weight='bold',
         )
         fig.text(
-            0.02, 0.25, "VELOCITY", rotation=90, va="center", fontsize=12, weight="bold"
+            0.02, 0.25, 'VELOCITY', rotation=90, va='center', fontsize=12, weight='bold'
         )
 
         fig.suptitle(
@@ -1861,12 +1861,12 @@ class TestDiagnosticPlots:
         )
         plt.tight_layout(rect=[0.03, 0, 1, 0.99])
         plt.savefig(
-            output_dir / "resolution_snr_grid.png", dpi=150, bbox_inches="tight"
+            output_dir / 'resolution_snr_grid.png', dpi=150, bbox_inches='tight'
         )
         plt.close()
 
         print(
-            f"✓ Saved resolution/SNR grid with intensity+velocity: {output_dir / 'resolution_snr_grid.png'}"
+            f'✓ Saved resolution/SNR grid with intensity+velocity: {output_dir / "resolution_snr_grid.png"}'
         )
 
     def test_glamour_shot(self, output_dir):
@@ -1886,16 +1886,16 @@ class TestDiagnosticPlots:
 
         # High resolution for truth (top row) - zoom to ±2" at 0.025"/pix
         image_pars_highres = ImagePars(
-            shape=(160, 160), pixel_scale=0.025, indexing="ij"
+            shape=(160, 160), pixel_scale=0.025, indexing='ij'
         )
         # Half resolution for data vectors (bottom row)
-        image_pars_datavec = ImagePars(shape=(64, 64), pixel_scale=0.1, indexing="ij")
+        image_pars_datavec = ImagePars(shape=(64, 64), pixel_scale=0.1, indexing='ij')
         target_z = 0.6
 
         # Config for high-res truth
         config_highres = TNGRenderConfig(
             image_pars=image_pars_highres,
-            band="r",
+            band='r',
             use_native_orientation=True,
             use_cic_gridding=True,
             target_redshift=target_z,
@@ -1904,7 +1904,7 @@ class TestDiagnosticPlots:
         # Config for lower-res data vectors
         config_datavec = TNGRenderConfig(
             image_pars=image_pars_datavec,
-            band="r",
+            band='r',
             use_native_orientation=True,
             use_cic_gridding=True,
             target_redshift=target_z,
@@ -1937,19 +1937,19 @@ class TestDiagnosticPlots:
         vmin_int, vmax_int = self.compute_robust_intensity_bounds(int_log, log=True)
         im00 = ax00.imshow(
             int_log,
-            origin="lower",
-            cmap="viridis",
-            aspect="equal",
+            origin='lower',
+            cmap='viridis',
+            aspect='equal',
             vmin=vmin_int,
             vmax=vmax_int,
             extent=extent_highres,
         )
-        ax00.set_title("r-band Flux (Truth)", fontsize=12, weight="bold")
-        ax00.set_xlabel("X [arcsec]", fontsize=10)
-        ax00.set_ylabel("Y [arcsec]", fontsize=10)
-        self.add_colorbar_matching_height(im00, ax00, label="log$_{10}$(Flux)")
+        ax00.set_title('r-band Flux (Truth)', fontsize=12, weight='bold')
+        ax00.set_xlabel('X [arcsec]', fontsize=10)
+        ax00.set_ylabel('Y [arcsec]', fontsize=10)
+        self.add_colorbar_matching_height(im00, ax00, label='log$_{10}$(Flux)')
         self.add_scale_markers(
-            ax00, image_pars_highres, scale_bar_arcsec=0.5, color="white"
+            ax00, image_pars_highres, scale_bar_arcsec=0.5, color='white'
         )
         ax00.text(
             0.95,
@@ -1957,9 +1957,9 @@ class TestDiagnosticPlots:
             'pix=0.025"',
             transform=ax00.transAxes,
             fontsize=9,
-            va="top",
-            ha="right",
-            bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
+            va='top',
+            ha='right',
+            bbox=dict(boxstyle='round', facecolor='white', alpha=0.8),
         )
 
         # Top middle: Hα flux (from SFR)
@@ -1968,19 +1968,19 @@ class TestDiagnosticPlots:
         vmin_ha, vmax_ha = self.compute_robust_intensity_bounds(halpha_log, log=True)
         im01 = ax01.imshow(
             halpha_log,
-            origin="lower",
-            cmap="viridis",
-            aspect="equal",
+            origin='lower',
+            cmap='viridis',
+            aspect='equal',
             vmin=vmin_ha,
             vmax=vmax_ha,
             extent=extent_highres,
         )
-        ax01.set_title("Hα Flux (SFR proxy, Truth)", fontsize=12, weight="bold")
-        ax01.set_xlabel("X [arcsec]", fontsize=10)
-        ax01.set_ylabel("Y [arcsec]", fontsize=10)
-        self.add_colorbar_matching_height(im01, ax01, label="log$_{10}$(SFR)")
+        ax01.set_title('Hα Flux (SFR proxy, Truth)', fontsize=12, weight='bold')
+        ax01.set_xlabel('X [arcsec]', fontsize=10)
+        ax01.set_ylabel('Y [arcsec]', fontsize=10)
+        self.add_colorbar_matching_height(im01, ax01, label='log$_{10}$(SFR)')
         self.add_scale_markers(
-            ax01, image_pars_highres, scale_bar_arcsec=0.5, color="white"
+            ax01, image_pars_highres, scale_bar_arcsec=0.5, color='white'
         )
         ax01.text(
             0.95,
@@ -1988,9 +1988,9 @@ class TestDiagnosticPlots:
             'pix=0.025"',
             transform=ax01.transAxes,
             fontsize=9,
-            va="top",
-            ha="right",
-            bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
+            va='top',
+            ha='right',
+            bbox=dict(boxstyle='round', facecolor='white', alpha=0.8),
         )
 
         # Top right: LoS velocity
@@ -1998,16 +1998,16 @@ class TestDiagnosticPlots:
         vmax_vel = np.nanmax(np.abs(vel_clean))
         im02 = ax02.imshow(
             vel_clean,
-            origin="lower",
-            cmap="RdBu_r",
-            aspect="equal",
+            origin='lower',
+            cmap='RdBu_r',
+            aspect='equal',
             norm=MidpointNormalize(vmin=-vmax_vel, vmax=vmax_vel, midpoint=0),
             extent=extent_highres,
         )
-        ax02.set_title("LoS Velocity (Truth)", fontsize=12, weight="bold")
-        ax02.set_xlabel("X [arcsec]", fontsize=10)
-        ax02.set_ylabel("Y [arcsec]", fontsize=10)
-        self.add_colorbar_matching_height(im02, ax02, label=r"$v_\mathrm{LOS}$ [km/s]")
+        ax02.set_title('LoS Velocity (Truth)', fontsize=12, weight='bold')
+        ax02.set_xlabel('X [arcsec]', fontsize=10)
+        ax02.set_ylabel('Y [arcsec]', fontsize=10)
+        self.add_colorbar_matching_height(im02, ax02, label=r'$v_\mathrm{LOS}$ [km/s]')
         self.add_scale_markers(ax02, image_pars_highres, scale_bar_arcsec=0.5)
         ax02.text(
             0.95,
@@ -2015,9 +2015,9 @@ class TestDiagnosticPlots:
             'pix=0.025"',
             transform=ax02.transAxes,
             fontsize=9,
-            va="top",
-            ha="right",
-            bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
+            va='top',
+            ha='right',
+            bbox=dict(boxstyle='round', facecolor='white', alpha=0.8),
         )
 
         # Bottom row: Lower-res with noise (Data Vectors)
@@ -2031,19 +2031,19 @@ class TestDiagnosticPlots:
         )
         im10 = ax10.imshow(
             int_noisy_log,
-            origin="lower",
-            cmap="viridis",
-            aspect="equal",
+            origin='lower',
+            cmap='viridis',
+            aspect='equal',
             vmin=vmin_int_noisy,
             vmax=vmax_int_noisy,
             extent=extent_datavec,
         )
-        ax10.set_title("r-band DataVector (SNR=250)", fontsize=12, weight="bold")
-        ax10.set_xlabel("X [arcsec]", fontsize=10)
-        ax10.set_ylabel("Y [arcsec]", fontsize=10)
-        self.add_colorbar_matching_height(im10, ax10, label="log$_{10}$(Flux)")
+        ax10.set_title('r-band DataVector (SNR=250)', fontsize=12, weight='bold')
+        ax10.set_xlabel('X [arcsec]', fontsize=10)
+        ax10.set_ylabel('Y [arcsec]', fontsize=10)
+        self.add_colorbar_matching_height(im10, ax10, label='log$_{10}$(Flux)')
         self.add_scale_markers(
-            ax10, image_pars_datavec, scale_bar_arcsec=1.0, color="white"
+            ax10, image_pars_datavec, scale_bar_arcsec=1.0, color='white'
         )
         ax10.text(
             0.95,
@@ -2051,9 +2051,9 @@ class TestDiagnosticPlots:
             'pix=0.1"',
             transform=ax10.transAxes,
             fontsize=9,
-            va="top",
-            ha="right",
-            bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
+            va='top',
+            ha='right',
+            bbox=dict(boxstyle='round', facecolor='white', alpha=0.8),
         )
 
         # Bottom middle: Hα DataVector - compute separate bounds for noisy data
@@ -2066,19 +2066,19 @@ class TestDiagnosticPlots:
         )
         im11 = ax11.imshow(
             halpha_noisy_log,
-            origin="lower",
-            cmap="viridis",
-            aspect="equal",
+            origin='lower',
+            cmap='viridis',
+            aspect='equal',
             vmin=vmin_ha_noisy,
             vmax=vmax_ha_noisy,
             extent=extent_datavec,
         )
-        ax11.set_title("Hα DataVector (SNR=250)", fontsize=12, weight="bold")
-        ax11.set_xlabel("X [arcsec]", fontsize=10)
-        ax11.set_ylabel("Y [arcsec]", fontsize=10)
-        self.add_colorbar_matching_height(im11, ax11, label="log$_{10}$(SFR)")
+        ax11.set_title('Hα DataVector (SNR=250)', fontsize=12, weight='bold')
+        ax11.set_xlabel('X [arcsec]', fontsize=10)
+        ax11.set_ylabel('Y [arcsec]', fontsize=10)
+        self.add_colorbar_matching_height(im11, ax11, label='log$_{10}$(SFR)')
         self.add_scale_markers(
-            ax11, image_pars_datavec, scale_bar_arcsec=1.0, color="white"
+            ax11, image_pars_datavec, scale_bar_arcsec=1.0, color='white'
         )
         ax11.text(
             0.95,
@@ -2086,25 +2086,25 @@ class TestDiagnosticPlots:
             'pix=0.1"',
             transform=ax11.transAxes,
             fontsize=9,
-            va="top",
-            ha="right",
-            bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
+            va='top',
+            ha='right',
+            bbox=dict(boxstyle='round', facecolor='white', alpha=0.8),
         )
 
         # Bottom right: Velocity DataVector
         ax12 = fig.add_subplot(gs[1, 2])
         im12 = ax12.imshow(
             vel_noisy,
-            origin="lower",
-            cmap="RdBu_r",
-            aspect="equal",
+            origin='lower',
+            cmap='RdBu_r',
+            aspect='equal',
             norm=MidpointNormalize(vmin=-vmax_vel, vmax=vmax_vel, midpoint=0),
             extent=extent_datavec,
         )
-        ax12.set_title("Velocity DataVector (SNR=50)", fontsize=12, weight="bold")
-        ax12.set_xlabel("X [arcsec]", fontsize=10)
-        ax12.set_ylabel("Y [arcsec]", fontsize=10)
-        self.add_colorbar_matching_height(im12, ax12, label=r"$v_\mathrm{LOS}$ [km/s]")
+        ax12.set_title('Velocity DataVector (SNR=50)', fontsize=12, weight='bold')
+        ax12.set_xlabel('X [arcsec]', fontsize=10)
+        ax12.set_ylabel('Y [arcsec]', fontsize=10)
+        self.add_colorbar_matching_height(im12, ax12, label=r'$v_\mathrm{LOS}$ [km/s]')
         self.add_scale_markers(ax12, image_pars_datavec, scale_bar_arcsec=1.0)
         ax12.text(
             0.95,
@@ -2112,18 +2112,18 @@ class TestDiagnosticPlots:
             'pix=0.1"',
             transform=ax12.transAxes,
             fontsize=9,
-            va="top",
-            ha="right",
-            bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
+            va='top',
+            ha='right',
+            bbox=dict(boxstyle='round', facecolor='white', alpha=0.8),
         )
 
-        fig.suptitle(f"TNG50 Galaxy (SubhaloID=8, z={target_z})", fontsize=14, y=0.98)
+        fig.suptitle(f'TNG50 Galaxy (SubhaloID=8, z={target_z})', fontsize=14, y=0.98)
         plt.savefig(
-            output_dir / "glamour_shot_subhalo8.png", dpi=150, bbox_inches="tight"
+            output_dir / 'glamour_shot_subhalo8.png', dpi=150, bbox_inches='tight'
         )
         plt.close()
 
-        print(f"✓ Saved glamour shot: {output_dir / 'glamour_shot_subhalo8.png'}")
+        print(f'✓ Saved glamour shot: {output_dir / "glamour_shot_subhalo8.png"}')
 
     def test_orientation_sweep_inclination(self, output_dir):
         """
@@ -2152,7 +2152,7 @@ class TestDiagnosticPlots:
 
         # Zoomed out view: larger FOV
         image_pars = ImagePars(
-            shape=(80, 80), pixel_scale=0.05, indexing="ij"
+            shape=(80, 80), pixel_scale=0.05, indexing='ij'
         )  # 4 arcsec FOV
         target_z = 0.5  # Slightly closer for larger apparent size
         snr = None
@@ -2165,9 +2165,9 @@ class TestDiagnosticPlots:
 
         # Generate both modes: with and without gas-stellar offset preservation
         for preserve_offset in [True, False]:
-            mode_label = "offset_preserved" if preserve_offset else "aligned"
+            mode_label = 'offset_preserved' if preserve_offset else 'aligned'
             mode_title = (
-                "Gas offset preserved" if preserve_offset else "Gas-stellar aligned"
+                'Gas offset preserved' if preserve_offset else 'Gas-stellar aligned'
             )
 
             # First pass: generate all maps to get consistent colorbar ranges
@@ -2179,7 +2179,7 @@ class TestDiagnosticPlots:
             # Native orientation
             config_native = TNGRenderConfig(
                 image_pars=image_pars,
-                band="r",
+                band='r',
                 use_native_orientation=True,
                 use_cic_gridding=True,
                 target_redshift=target_z,
@@ -2190,23 +2190,23 @@ class TestDiagnosticPlots:
             all_velocities.append(vel_native)
             native_cosi = np.cos(np.deg2rad(gen.native_inclination_deg))
             titles_int.append(
-                f"Native\ninc={gen.native_inclination_deg:.1f}°\ncos(i)={native_cosi:.2f}"
+                f'Native\ninc={gen.native_inclination_deg:.1f}°\ncos(i)={native_cosi:.2f}'
             )
-            titles_vel.append("")
+            titles_vel.append('')
 
             # Custom orientations
             for cosi, inc_deg in zip(cosi_vals, inc_deg_vals):
                 pars = {
-                    "cosi": cosi,
-                    "theta_int": np.deg2rad(gen.native_pa_deg),
-                    "g1": 0.0,
-                    "g2": 0.0,
-                    "x0": 0.0,
-                    "y0": 0.0,
+                    'cosi': cosi,
+                    'theta_int': np.deg2rad(gen.native_pa_deg),
+                    'g1': 0.0,
+                    'g2': 0.0,
+                    'x0': 0.0,
+                    'y0': 0.0,
                 }
                 config = TNGRenderConfig(
                     image_pars=image_pars,
-                    band="r",
+                    band='r',
                     use_native_orientation=False,
                     use_cic_gridding=True,
                     target_redshift=target_z,
@@ -2217,8 +2217,8 @@ class TestDiagnosticPlots:
                 velocity, _ = gen.generate_velocity_map(config, snr=snr, seed=42)
                 all_intensities.append(intensity)
                 all_velocities.append(velocity)
-                titles_int.append(f"inc={inc_deg:.0f}°\ncos(i)={cosi:.1f}")
-                titles_vel.append("")
+                titles_int.append(f'inc={inc_deg:.0f}°\ncos(i)={cosi:.1f}')
+                titles_vel.append('')
 
             # Compute global colorbar ranges
             # Use np.clip to avoid log10 of negative/zero values
@@ -2244,9 +2244,9 @@ class TestDiagnosticPlots:
                 nrows_ncols=(1, n_cols),
                 axes_pad=0.05,
                 share_all=True,
-                cbar_location="right",
-                cbar_mode="single",
-                cbar_size="3%",
+                cbar_location='right',
+                cbar_mode='single',
+                cbar_size='3%',
                 cbar_pad=0.1,
             )
 
@@ -2254,9 +2254,9 @@ class TestDiagnosticPlots:
                 int_log = np.log10(np.clip(intensity, 1e-10, None))
                 im = grid_int[idx].imshow(
                     int_log,
-                    origin="lower",
-                    cmap="viridis",
-                    aspect="equal",
+                    origin='lower',
+                    cmap='viridis',
+                    aspect='equal',
                     vmin=vmin_int,
                     vmax=vmax_int,
                     extent=extent,
@@ -2266,12 +2266,12 @@ class TestDiagnosticPlots:
                 grid_int[idx].set_yticks([])
                 if idx == 0:  # Scale bar on native column
                     self.add_scale_markers(
-                        grid_int[idx], image_pars, scale_bar_arcsec=1.0, color="white"
+                        grid_int[idx], image_pars, scale_bar_arcsec=1.0, color='white'
                     )
 
-            grid_int[0].set_ylabel("Intensity", fontsize=10, weight="bold")
+            grid_int[0].set_ylabel('Intensity', fontsize=10, weight='bold')
             grid_int.cbar_axes[0].colorbar(im)
-            grid_int.cbar_axes[0].set_ylabel("log(Flux)", fontsize=9)
+            grid_int.cbar_axes[0].set_ylabel('log(Flux)', fontsize=9)
 
             # Velocity row (bottom)
             grid_vel = ImageGrid(
@@ -2280,18 +2280,18 @@ class TestDiagnosticPlots:
                 nrows_ncols=(1, n_cols),
                 axes_pad=0.05,
                 share_all=True,
-                cbar_location="right",
-                cbar_mode="single",
-                cbar_size="3%",
+                cbar_location='right',
+                cbar_mode='single',
+                cbar_size='3%',
                 cbar_pad=0.1,
             )
 
             for idx, velocity in enumerate(all_velocities):
                 im = grid_vel[idx].imshow(
                     velocity,
-                    origin="lower",
-                    cmap="RdBu_r",
-                    aspect="equal",
+                    origin='lower',
+                    cmap='RdBu_r',
+                    aspect='equal',
                     norm=MidpointNormalize(vmin=-vmax_vel, vmax=vmax_vel, midpoint=0),
                     extent=extent,
                 )
@@ -2302,24 +2302,24 @@ class TestDiagnosticPlots:
                         grid_vel[idx], image_pars, scale_bar_arcsec=1.0
                     )
 
-            grid_vel[0].set_ylabel("Velocity", fontsize=10, weight="bold")
+            grid_vel[0].set_ylabel('Velocity', fontsize=10, weight='bold')
             grid_vel.cbar_axes[0].colorbar(im)
-            grid_vel.cbar_axes[0].set_ylabel("v [km/s]", fontsize=9)
+            grid_vel.cbar_axes[0].set_ylabel('v [km/s]', fontsize=9)
 
             # Add info about gas-stellar offset
             offset_angle = gen._gas_stellar_L_angle_deg
             fig.suptitle(
-                f"TNG50 SubhaloID=8: Inclination Sweep ({mode_title})\n"
-                f"Gas-stellar L offset: {offset_angle:.1f}°, z={target_z}",
+                f'TNG50 SubhaloID=8: Inclination Sweep ({mode_title})\n'
+                f'Gas-stellar L offset: {offset_angle:.1f}°, z={target_z}',
                 fontsize=11,
                 y=1.02,
             )
 
-            out_path = output_dir / f"orientation_sweep_inclination_{mode_label}.png"
-            plt.savefig(out_path, dpi=150, bbox_inches="tight")
+            out_path = output_dir / f'orientation_sweep_inclination_{mode_label}.png'
+            plt.savefig(out_path, dpi=150, bbox_inches='tight')
             plt.close()
 
-            print(f"✓ Saved inclination sweep ({mode_label}): {out_path}")
+            print(f'✓ Saved inclination sweep ({mode_label}): {out_path}')
 
     def test_orientation_sweep_inclination_multi_galaxy(self, output_dir):
         """
@@ -2340,7 +2340,7 @@ class TestDiagnosticPlots:
         galaxy_indices = range(min(5, len(tng_data)))
 
         # Common parameters
-        image_pars = ImagePars(shape=(80, 80), pixel_scale=0.05, indexing="ij")
+        image_pars = ImagePars(shape=(80, 80), pixel_scale=0.05, indexing='ij')
         target_z = 0.5
         snr = None
         preserve_offset = True  # Use gas offset preserved mode
@@ -2357,28 +2357,28 @@ class TestDiagnosticPlots:
         for gal_idx in galaxy_indices:
             galaxy = tng_data[gal_idx]
             gen = TNGDataVectorGenerator(galaxy)
-            subhalo_id = galaxy["subhalo"]["SubhaloID"]
+            subhalo_id = galaxy['subhalo']['SubhaloID']
 
             print(
-                f"Generating inclination sweep for galaxy {gal_idx} (SubhaloID={subhalo_id})..."
+                f'Generating inclination sweep for galaxy {gal_idx} (SubhaloID={subhalo_id})...'
             )
 
             # Collect orientation diagnostics for summary
             orientation_summary.append(
                 {
-                    "SubhaloID": subhalo_id,
-                    "Catalog_Inc_deg": gen.native_inclination_deg,
-                    "Kinematic_Inc_deg": getattr(
-                        gen, "_kinematic_inc_stellar_deg", 0.0
+                    'SubhaloID': subhalo_id,
+                    'Catalog_Inc_deg': gen.native_inclination_deg,
+                    'Kinematic_Inc_deg': getattr(
+                        gen, '_kinematic_inc_stellar_deg', 0.0
                     ),
-                    "Catalog_vs_Kinematic_Offset_deg": getattr(
-                        gen, "_catalog_vs_kinematic_offset_deg", 0.0
+                    'Catalog_vs_Kinematic_Offset_deg': getattr(
+                        gen, '_catalog_vs_kinematic_offset_deg', 0.0
                     ),
-                    "Gas_Stellar_L_Offset_deg": getattr(
-                        gen, "_gas_stellar_L_angle_deg", 0.0
+                    'Gas_Stellar_L_Offset_deg': getattr(
+                        gen, '_gas_stellar_L_angle_deg', 0.0
                     ),
-                    "Kinematic_Inc_Gas_deg": getattr(
-                        gen, "_kinematic_inc_gas_deg", 0.0
+                    'Kinematic_Inc_Gas_deg': getattr(
+                        gen, '_kinematic_inc_gas_deg', 0.0
                     ),
                 }
             )
@@ -2392,7 +2392,7 @@ class TestDiagnosticPlots:
             # Native orientation
             config_native = TNGRenderConfig(
                 image_pars=image_pars,
-                band="r",
+                band='r',
                 use_native_orientation=True,
                 use_cic_gridding=True,
                 target_redshift=target_z,
@@ -2403,23 +2403,23 @@ class TestDiagnosticPlots:
             all_velocities.append(vel_native)
             native_cosi = np.cos(np.deg2rad(gen.native_inclination_deg))
             titles_int.append(
-                f"Native\ninc={gen.native_inclination_deg:.1f}°\ncos(i)={native_cosi:.2f}"
+                f'Native\ninc={gen.native_inclination_deg:.1f}°\ncos(i)={native_cosi:.2f}'
             )
-            titles_vel.append("")
+            titles_vel.append('')
 
             # Custom orientations
             for cosi, inc_deg in zip(cosi_vals, inc_deg_vals):
                 pars = {
-                    "cosi": cosi,
-                    "theta_int": np.deg2rad(gen.native_pa_deg),
-                    "g1": 0.0,
-                    "g2": 0.0,
-                    "x0": 0.0,
-                    "y0": 0.0,
+                    'cosi': cosi,
+                    'theta_int': np.deg2rad(gen.native_pa_deg),
+                    'g1': 0.0,
+                    'g2': 0.0,
+                    'x0': 0.0,
+                    'y0': 0.0,
                 }
                 config = TNGRenderConfig(
                     image_pars=image_pars,
-                    band="r",
+                    band='r',
                     use_native_orientation=False,
                     use_cic_gridding=True,
                     target_redshift=target_z,
@@ -2430,8 +2430,8 @@ class TestDiagnosticPlots:
                 velocity, _ = gen.generate_velocity_map(config, snr=snr, seed=42)
                 all_intensities.append(intensity)
                 all_velocities.append(velocity)
-                titles_int.append(f"inc={inc_deg:.0f}°\ncos(i)={cosi:.1f}")
-                titles_vel.append("")
+                titles_int.append(f'inc={inc_deg:.0f}°\ncos(i)={cosi:.1f}')
+                titles_vel.append('')
 
             # Compute colorbar ranges
             # Use np.clip to avoid log10 of negative/zero values
@@ -2457,9 +2457,9 @@ class TestDiagnosticPlots:
                 nrows_ncols=(1, n_cols),
                 axes_pad=0.05,
                 share_all=True,
-                cbar_location="right",
-                cbar_mode="single",
-                cbar_size="3%",
+                cbar_location='right',
+                cbar_mode='single',
+                cbar_size='3%',
                 cbar_pad=0.1,
             )
 
@@ -2468,19 +2468,19 @@ class TestDiagnosticPlots:
                 im = grid_int[idx].imshow(
                     int_log,
                     extent=extent,
-                    origin="lower",
-                    cmap="viridis",
+                    origin='lower',
+                    cmap='viridis',
                     vmin=vmin_int,
                     vmax=vmax_int,
-                    interpolation="nearest",
+                    interpolation='nearest',
                 )
                 grid_int[idx].set_title(title, fontsize=8)
                 if idx == 0:
-                    grid_int[idx].set_ylabel("Intensity", fontsize=10)
+                    grid_int[idx].set_ylabel('Intensity', fontsize=10)
                 grid_int[idx].tick_params(labelsize=6)
 
             grid_int.cbar_axes[0].colorbar(im)
-            grid_int.cbar_axes[0].set_ylabel("log(Flux)", fontsize=8)
+            grid_int.cbar_axes[0].set_ylabel('log(Flux)', fontsize=8)
 
             # Velocity row
             grid_vel = ImageGrid(
@@ -2489,9 +2489,9 @@ class TestDiagnosticPlots:
                 nrows_ncols=(1, n_cols),
                 axes_pad=0.05,
                 share_all=True,
-                cbar_location="right",
-                cbar_mode="single",
-                cbar_size="3%",
+                cbar_location='right',
+                cbar_mode='single',
+                cbar_size='3%',
                 cbar_pad=0.1,
             )
 
@@ -2499,26 +2499,26 @@ class TestDiagnosticPlots:
                 im = grid_vel[idx].imshow(
                     velocity,
                     extent=extent,
-                    origin="lower",
-                    cmap="RdBu_r",
+                    origin='lower',
+                    cmap='RdBu_r',
                     vmin=-vmax_vel,
                     vmax=vmax_vel,
-                    interpolation="nearest",
+                    interpolation='nearest',
                 )
                 grid_vel[idx].set_title(title, fontsize=8)
                 if idx == 0:
-                    grid_vel[idx].set_ylabel("Velocity", fontsize=10)
+                    grid_vel[idx].set_ylabel('Velocity', fontsize=10)
                 grid_vel[idx].tick_params(labelsize=6)
 
             grid_vel.cbar_axes[0].colorbar(im)
-            grid_vel.cbar_axes[0].set_ylabel("v [km/s]", fontsize=8)
+            grid_vel.cbar_axes[0].set_ylabel('v [km/s]', fontsize=8)
 
             # Quantitative diagnostic: compute vertical extent at each inclination
-            print(f"\n  SubhaloID={subhalo_id} Vertical Extent Analysis:")
+            print(f'\n  SubhaloID={subhalo_id} Vertical Extent Analysis:')
             print(
-                f"  {'Inclination':<12} {'cos(i)':<8} {'RMS Height':<12} {'90th Pct':<12}"
+                f'  {"Inclination":<12} {"cos(i)":<8} {"RMS Height":<12} {"90th Pct":<12}'
             )
-            print(f"  {'-' * 50}")
+            print(f'  {"-" * 50}')
 
             vertical_extents_rms = []
             vertical_extents_90 = []
@@ -2540,9 +2540,9 @@ class TestDiagnosticPlots:
             vertical_extents_rms.append(rms_height_native)
             vertical_extents_90.append(p90_height_native)
             native_cosi_val = np.cos(np.deg2rad(gen.native_inclination_deg))
-            inc_labels.append(f"Native ({gen.native_inclination_deg:.1f}°)")
+            inc_labels.append(f'Native ({gen.native_inclination_deg:.1f}°)')
             print(
-                f"  {'Native':<12} {native_cosi_val:<8.2f} {rms_height_native:<12.3f} {p90_height_native:<12.3f}"
+                f'  {"Native":<12} {native_cosi_val:<8.2f} {rms_height_native:<12.3f} {p90_height_native:<12.3f}'
             )
 
             # Analyze custom orientations
@@ -2556,33 +2556,33 @@ class TestDiagnosticPlots:
                 )
                 vertical_extents_rms.append(rms_height)
                 vertical_extents_90.append(p90_height)
-                inc_labels.append(f"{inc_deg:.0f}°")
+                inc_labels.append(f'{inc_deg:.0f}°')
                 print(
-                    f"  {inc_deg:<12.0f} {cosi:<8.2f} {rms_height:<12.3f} {p90_height:<12.3f}"
+                    f'  {inc_deg:<12.0f} {cosi:<8.2f} {rms_height:<12.3f} {p90_height:<12.3f}'
                 )
 
             # Find minimum
             min_idx_rms = np.argmin(vertical_extents_rms)
             min_idx_90 = np.argmin(vertical_extents_90)
-            print(f"\n  Minimum RMS height at: {inc_labels[min_idx_rms]}")
-            print(f"  Minimum 90th pct height at: {inc_labels[min_idx_90]}\n")
+            print(f'\n  Minimum RMS height at: {inc_labels[min_idx_rms]}')
+            print(f'  Minimum 90th pct height at: {inc_labels[min_idx_90]}\n')
 
             # Save diagnostic data to CSV
             csv_path = (
-                output_dir / f"vertical_extent_diagnostic_subhalo{subhalo_id}.csv"
+                output_dir / f'vertical_extent_diagnostic_subhalo{subhalo_id}.csv'
             )
             import csv
 
-            with open(csv_path, "w", newline="") as csvfile:
+            with open(csv_path, 'w', newline='') as csvfile:
                 writer = csv.writer(csvfile)
                 writer.writerow(
                     [
-                        "SubhaloID",
-                        "Inclination_deg",
-                        "cos_i",
-                        "RMS_Height_arcsec",
-                        "P90_Height_arcsec",
-                        "is_native",
+                        'SubhaloID',
+                        'Inclination_deg',
+                        'cos_i',
+                        'RMS_Height_arcsec',
+                        'P90_Height_arcsec',
+                        'is_native',
                     ]
                 )
 
@@ -2611,72 +2611,72 @@ class TestDiagnosticPlots:
                         ]
                     )
 
-            print(f"  ✓ Saved diagnostic CSV: {csv_path}")
+            print(f'  ✓ Saved diagnostic CSV: {csv_path}')
 
             # Title with enhanced diagnostics
-            gas_stellar_angle = getattr(gen, "_gas_stellar_L_angle_deg", 0.0)
-            kinematic_inc = getattr(gen, "_kinematic_inc_stellar_deg", 0.0)
+            gas_stellar_angle = getattr(gen, '_gas_stellar_L_angle_deg', 0.0)
+            kinematic_inc = getattr(gen, '_kinematic_inc_stellar_deg', 0.0)
             catalog_kinematic_offset = getattr(
-                gen, "_catalog_vs_kinematic_offset_deg", 0.0
+                gen, '_catalog_vs_kinematic_offset_deg', 0.0
             )
 
             fig.suptitle(
-                f"TNG50 SubhaloID={subhalo_id}: Inclination Sweep (Gas offset preserved)\n"
-                f"Gas-stellar L offset: {gas_stellar_angle:.1f}°, "
-                f"Catalog inc: {gen.native_inclination_deg:.1f}° vs Kinematic inc: {kinematic_inc:.1f}° "
-                f"(Δ={catalog_kinematic_offset:.1f}°), z={target_z}",
+                f'TNG50 SubhaloID={subhalo_id}: Inclination Sweep (Gas offset preserved)\n'
+                f'Gas-stellar L offset: {gas_stellar_angle:.1f}°, '
+                f'Catalog inc: {gen.native_inclination_deg:.1f}° vs Kinematic inc: {kinematic_inc:.1f}° '
+                f'(Δ={catalog_kinematic_offset:.1f}°), z={target_z}',
                 fontsize=10,
                 y=0.98,
             )
 
             out_path = (
-                output_dir / f"orientation_sweep_inclination_subhalo{subhalo_id}.png"
+                output_dir / f'orientation_sweep_inclination_subhalo{subhalo_id}.png'
             )
-            plt.savefig(out_path, dpi=150, bbox_inches="tight")
+            plt.savefig(out_path, dpi=150, bbox_inches='tight')
             plt.close()
 
             # Print diagnostic summary
-            print(f"\n  Orientation Diagnostics:")
-            print(f"    Catalog (morphological) inc: {gen.native_inclination_deg:.1f}°")
-            print(f"    Kinematic (from L) inc: {kinematic_inc:.1f}°")
-            print(f"    Catalog vs Kinematic offset: {catalog_kinematic_offset:.1f}°")
-            print(f"    Gas-stellar L angle: {gas_stellar_angle:.1f}°")
+            print(f'\n  Orientation Diagnostics:')
+            print(f'    Catalog (morphological) inc: {gen.native_inclination_deg:.1f}°')
+            print(f'    Kinematic (from L) inc: {kinematic_inc:.1f}°')
+            print(f'    Catalog vs Kinematic offset: {catalog_kinematic_offset:.1f}°')
+            print(f'    Gas-stellar L angle: {gas_stellar_angle:.1f}°')
 
-            print(f"\n  ✓ Saved: {out_path}")
+            print(f'\n  ✓ Saved: {out_path}')
 
         # Write summary CSV with orientation diagnostics for all galaxies
-        summary_csv_path = output_dir / "orientation_diagnostics_summary.csv"
-        with open(summary_csv_path, "w", newline="") as csvfile:
+        summary_csv_path = output_dir / 'orientation_diagnostics_summary.csv'
+        with open(summary_csv_path, 'w', newline='') as csvfile:
             fieldnames = [
-                "SubhaloID",
-                "Catalog_Inc_deg",
-                "Kinematic_Inc_deg",
-                "Catalog_vs_Kinematic_Offset_deg",
-                "Gas_Stellar_L_Offset_deg",
-                "Kinematic_Inc_Gas_deg",
+                'SubhaloID',
+                'Catalog_Inc_deg',
+                'Kinematic_Inc_deg',
+                'Catalog_vs_Kinematic_Offset_deg',
+                'Gas_Stellar_L_Offset_deg',
+                'Kinematic_Inc_Gas_deg',
             ]
             writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
             writer.writeheader()
             for row in orientation_summary:
                 writer.writerow(row)
 
-        print(f"\n✓ Saved orientation diagnostics summary: {summary_csv_path}")
+        print(f'\n✓ Saved orientation diagnostics summary: {summary_csv_path}')
 
         # Print summary table
-        print("\n" + "=" * 80)
-        print("ORIENTATION DIAGNOSTICS SUMMARY")
-        print("=" * 80)
+        print('\n' + '=' * 80)
+        print('ORIENTATION DIAGNOSTICS SUMMARY')
+        print('=' * 80)
         print(
-            f"{'SubhaloID':<12} {'Cat. Inc':<10} {'Kin. Inc':<10} {'Cat-Kin Δ':<12} {'Gas-Star Δ':<12}"
+            f'{"SubhaloID":<12} {"Cat. Inc":<10} {"Kin. Inc":<10} {"Cat-Kin Δ":<12} {"Gas-Star Δ":<12}'
         )
-        print("-" * 80)
+        print('-' * 80)
         for row in orientation_summary:
             print(
-                f"{row['SubhaloID']:<12} {row['Catalog_Inc_deg']:<10.1f} "
-                f"{row['Kinematic_Inc_deg']:<10.1f} {row['Catalog_vs_Kinematic_Offset_deg']:<12.1f} "
-                f"{row['Gas_Stellar_L_Offset_deg']:<12.1f}"
+                f'{row["SubhaloID"]:<12} {row["Catalog_Inc_deg"]:<10.1f} '
+                f'{row["Kinematic_Inc_deg"]:<10.1f} {row["Catalog_vs_Kinematic_Offset_deg"]:<12.1f} '
+                f'{row["Gas_Stellar_L_Offset_deg"]:<12.1f}'
             )
-        print("=" * 80)
+        print('=' * 80)
 
     def test_orientation_sweep_pa(self, output_dir):
         """
@@ -2705,7 +2705,7 @@ class TestDiagnosticPlots:
 
         # Zoomed out view
         image_pars = ImagePars(
-            shape=(80, 80), pixel_scale=0.05, indexing="ij"
+            shape=(80, 80), pixel_scale=0.05, indexing='ij'
         )  # 4 arcsec FOV
         target_z = 0.5
         snr = None
@@ -2719,9 +2719,9 @@ class TestDiagnosticPlots:
 
         # Generate both modes: with and without gas-stellar offset preservation
         for preserve_offset in [True, False]:
-            mode_label = "offset_preserved" if preserve_offset else "aligned"
+            mode_label = 'offset_preserved' if preserve_offset else 'aligned'
             mode_title = (
-                "Gas offset preserved" if preserve_offset else "Gas-stellar aligned"
+                'Gas offset preserved' if preserve_offset else 'Gas-stellar aligned'
             )
 
             # Generate all maps
@@ -2729,16 +2729,16 @@ class TestDiagnosticPlots:
             all_velocities = []
             for pa_deg in pa_deg_vals:
                 pars = {
-                    "cosi": native_cosi,
-                    "theta_int": np.deg2rad(pa_deg),
-                    "g1": 0.0,
-                    "g2": 0.0,
-                    "x0": 0.0,
-                    "y0": 0.0,
+                    'cosi': native_cosi,
+                    'theta_int': np.deg2rad(pa_deg),
+                    'g1': 0.0,
+                    'g2': 0.0,
+                    'x0': 0.0,
+                    'y0': 0.0,
                 }
                 config = TNGRenderConfig(
                     image_pars=image_pars,
-                    band="r",
+                    band='r',
                     use_native_orientation=False,
                     use_cic_gridding=True,
                     target_redshift=target_z,
@@ -2773,9 +2773,9 @@ class TestDiagnosticPlots:
                 nrows_ncols=(1, n_pa),
                 axes_pad=0.05,
                 share_all=True,
-                cbar_location="right",
-                cbar_mode="single",
-                cbar_size="3%",
+                cbar_location='right',
+                cbar_mode='single',
+                cbar_size='3%',
                 cbar_pad=0.1,
             )
 
@@ -2785,24 +2785,24 @@ class TestDiagnosticPlots:
                 int_log = np.log10(intensity + 1e-10)
                 im = grid_int[idx].imshow(
                     int_log,
-                    origin="lower",
-                    cmap="viridis",
-                    aspect="equal",
+                    origin='lower',
+                    cmap='viridis',
+                    aspect='equal',
                     vmin=vmin_int,
                     vmax=vmax_int,
                     extent=extent,
                 )
-                grid_int[idx].set_title(f"PA={pa_deg:.0f}°", fontsize=9)
+                grid_int[idx].set_title(f'PA={pa_deg:.0f}°', fontsize=9)
                 grid_int[idx].set_xticks([])
                 grid_int[idx].set_yticks([])
                 if idx == 0:  # Scale bar on first column
                     self.add_scale_markers(
-                        grid_int[idx], image_pars, scale_bar_arcsec=1.0, color="white"
+                        grid_int[idx], image_pars, scale_bar_arcsec=1.0, color='white'
                     )
 
-            grid_int[0].set_ylabel("Intensity", fontsize=10, weight="bold")
+            grid_int[0].set_ylabel('Intensity', fontsize=10, weight='bold')
             grid_int.cbar_axes[0].colorbar(im)
-            grid_int.cbar_axes[0].set_ylabel("log(Flux)", fontsize=9)
+            grid_int.cbar_axes[0].set_ylabel('log(Flux)', fontsize=9)
 
             # Velocity row (bottom)
             grid_vel = ImageGrid(
@@ -2811,18 +2811,18 @@ class TestDiagnosticPlots:
                 nrows_ncols=(1, n_pa),
                 axes_pad=0.05,
                 share_all=True,
-                cbar_location="right",
-                cbar_mode="single",
-                cbar_size="3%",
+                cbar_location='right',
+                cbar_mode='single',
+                cbar_size='3%',
                 cbar_pad=0.1,
             )
 
             for idx, velocity in enumerate(all_velocities):
                 im = grid_vel[idx].imshow(
                     velocity,
-                    origin="lower",
-                    cmap="RdBu_r",
-                    aspect="equal",
+                    origin='lower',
+                    cmap='RdBu_r',
+                    aspect='equal',
                     norm=MidpointNormalize(vmin=-vmax_vel, vmax=vmax_vel, midpoint=0),
                     extent=extent,
                 )
@@ -2833,21 +2833,21 @@ class TestDiagnosticPlots:
                         grid_vel[idx], image_pars, scale_bar_arcsec=1.0
                     )
 
-            grid_vel[0].set_ylabel("Velocity", fontsize=10, weight="bold")
+            grid_vel[0].set_ylabel('Velocity', fontsize=10, weight='bold')
             grid_vel.cbar_axes[0].colorbar(im)
-            grid_vel.cbar_axes[0].set_ylabel("v [km/s]", fontsize=9)
+            grid_vel.cbar_axes[0].set_ylabel('v [km/s]', fontsize=9)
 
             # Add info about gas-stellar offset
             offset_angle = gen._gas_stellar_L_angle_deg
             fig.suptitle(
-                f"TNG50 SubhaloID=8: PA Sweep ({mode_title})\n"
-                f"inc={gen.native_inclination_deg:.1f}°, Gas-stellar L offset: {offset_angle:.1f}°",
+                f'TNG50 SubhaloID=8: PA Sweep ({mode_title})\n'
+                f'inc={gen.native_inclination_deg:.1f}°, Gas-stellar L offset: {offset_angle:.1f}°',
                 fontsize=11,
                 y=1.02,
             )
 
-            out_path = output_dir / f"orientation_sweep_pa_{mode_label}.png"
-            plt.savefig(out_path, dpi=150, bbox_inches="tight")
+            out_path = output_dir / f'orientation_sweep_pa_{mode_label}.png'
+            plt.savefig(out_path, dpi=150, bbox_inches='tight')
             plt.close()
 
-            print(f"✓ Saved PA sweep ({mode_label}): {out_path}")
+            print(f'✓ Saved PA sweep ({mode_label}): {out_path}')

--- a/tests/test_tng_sampling_diagnostics.py
+++ b/tests/test_tng_sampling_diagnostics.py
@@ -90,16 +90,16 @@ MAX_SAMPLING_TIME = 300  # 5 minutes per galaxy
 # ==============================================================================
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def tng_data():
     """Load TNG50 data once per module."""
     return TNG50MockData()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def output_dir():
     """Output directory for TNG sampling diagnostics."""
-    out_dir = get_test_dir() / "out" / "tng_diagnostics" / "sampling"
+    out_dir = get_test_dir() / 'out' / 'tng_diagnostics' / 'sampling'
     out_dir.mkdir(parents=True, exist_ok=True)
     return out_dir
 
@@ -107,7 +107,7 @@ def output_dir():
 @pytest.fixture
 def image_pars():
     """Standard test image parameters."""
-    return ImagePars(shape=IMAGE_SHAPE, pixel_scale=PIXEL_SCALE, indexing="ij")
+    return ImagePars(shape=IMAGE_SHAPE, pixel_scale=PIXEL_SCALE, indexing='ij')
 
 
 # ==============================================================================
@@ -139,7 +139,7 @@ def estimate_velocity_params(
 
     if valid_mask.sum() < 10:
         # Not enough valid pixels, return defaults
-        return {"v0": 0.0, "vcirc": 150.0, "vel_rscale": 0.5}
+        return {'v0': 0.0, 'vcirc': 150.0, 'vel_rscale': 0.5}
 
     valid_vel = velocity_map[valid_mask]
 
@@ -162,11 +162,11 @@ def estimate_velocity_params(
     vel_rscale = fov_arcsec / 6.0  # Rough estimate
 
     return {
-        "v0": v0,
-        "vcirc": vcirc_estimate,
-        "vel_rscale": vel_rscale,
-        "vel_x0": 0.0,  # Assume centered initially
-        "vel_y0": 0.0,
+        'v0': v0,
+        'vcirc': vcirc_estimate,
+        'vel_rscale': vel_rscale,
+        'vel_x0': 0.0,  # Assume centered initially
+        'vel_y0': 0.0,
     }
 
 
@@ -225,11 +225,11 @@ def estimate_intensity_params(
     total = intensity_map.sum()
     if total <= 0:
         return {
-            "flux": flux,
-            "int_rscale": 0.5,
-            "int_h_over_r": 0.1,
-            "int_x0": 0.0,
-            "int_y0": 0.0,
+            'flux': flux,
+            'int_rscale': 0.5,
+            'int_h_over_r': 0.1,
+            'int_x0': 0.0,
+            'int_y0': 0.0,
         }
 
     cumsum = np.cumsum(np.sort(intensity_map.ravel())[::-1])
@@ -246,11 +246,11 @@ def estimate_intensity_params(
     int_rscale = max(0.1, min(3.0, int_rscale))
 
     return {
-        "flux": flux,
-        "int_rscale": int_rscale,
-        "int_h_over_r": 0.1,
-        "int_x0": 0.0,
-        "int_y0": 0.0,
+        'flux': flux,
+        'int_rscale': int_rscale,
+        'int_h_over_r': 0.1,
+        'int_x0': 0.0,
+        'int_y0': 0.0,
     }
 
 
@@ -291,7 +291,7 @@ def create_tng_joint_inference_task(
     joint_model = KLModel(
         velocity_model=vel_model,
         intensity_model=int_model,
-        shared_pars={"cosi", "theta_int", "g1", "g2"},
+        shared_pars={'cosi', 'theta_int', 'g1', 'g2'},
     )
 
     # FOV for offset prior bounds
@@ -302,39 +302,39 @@ def create_tng_joint_inference_task(
     # This allows exploration since TNG doesn't match analytic models exactly
     prior_spec = {
         # Velocity params - wide priors
-        "v0": Gaussian(true_pars.get("v0", 0.0), 30.0),  # Wide Gaussian
-        "vcirc": TruncatedNormal(
-            true_pars.get("vcirc", 150.0), 100.0, 30, 500
+        'v0': Gaussian(true_pars.get('v0', 0.0), 30.0),  # Wide Gaussian
+        'vcirc': TruncatedNormal(
+            true_pars.get('vcirc', 150.0), 100.0, 30, 500
         ),  # Very wide
-        "vel_rscale": TruncatedNormal(true_pars.get("vel_rscale", 0.5), 0.5, 0.05, 3.0),
-        "vel_x0": TruncatedNormal(
-            true_pars.get("vel_x0", 0.0), 0.5, -offset_bound, offset_bound
+        'vel_rscale': TruncatedNormal(true_pars.get('vel_rscale', 0.5), 0.5, 0.05, 3.0),
+        'vel_x0': TruncatedNormal(
+            true_pars.get('vel_x0', 0.0), 0.5, -offset_bound, offset_bound
         ),
-        "vel_y0": TruncatedNormal(
-            true_pars.get("vel_y0", 0.0), 0.5, -offset_bound, offset_bound
+        'vel_y0': TruncatedNormal(
+            true_pars.get('vel_y0', 0.0), 0.5, -offset_bound, offset_bound
         ),
         # Intensity params - wide priors
         # After normalization, flux ~0.01 gives unit integrated flux in model
-        "flux": TruncatedNormal(true_pars.get("flux", 0.01), 0.02, 0.001, 0.1),
-        "int_rscale": TruncatedNormal(true_pars.get("int_rscale", 0.5), 0.5, 0.05, 3.0),
-        "int_h_over_r": 0.1,  # Fixed
-        "int_x0": TruncatedNormal(
-            true_pars.get("int_x0", 0.0), 0.5, -offset_bound, offset_bound
+        'flux': TruncatedNormal(true_pars.get('flux', 0.01), 0.02, 0.001, 0.1),
+        'int_rscale': TruncatedNormal(true_pars.get('int_rscale', 0.5), 0.5, 0.05, 3.0),
+        'int_h_over_r': 0.1,  # Fixed
+        'int_x0': TruncatedNormal(
+            true_pars.get('int_x0', 0.0), 0.5, -offset_bound, offset_bound
         ),
-        "int_y0": TruncatedNormal(
-            true_pars.get("int_y0", 0.0), 0.5, -offset_bound, offset_bound
+        'int_y0': TruncatedNormal(
+            true_pars.get('int_y0', 0.0), 0.5, -offset_bound, offset_bound
         ),
         # Shared geometric params - centered on known TNG values
-        "cosi": TruncatedNormal(true_pars["cosi"], 0.2, 0.01, 0.99),
-        "theta_int": TruncatedNormal(
-            true_pars["theta_int"],
+        'cosi': TruncatedNormal(true_pars['cosi'], 0.2, 0.01, 0.99),
+        'theta_int': TruncatedNormal(
+            true_pars['theta_int'],
             0.5,
             0.0,
             2 * np.pi,  # Full 0-2pi range
         ),
         # No shear for TNG (unlensed)
-        "g1": 0.0,
-        "g2": 0.0,
+        'g1': 0.0,
+        'g2': 0.0,
     }
 
     priors = PriorDict(prior_spec)
@@ -383,13 +383,13 @@ def evaluate_model_at_map(
     vel_model = task.model.velocity_model
     vel_pars = {k: full_pars[k] for k in vel_model.PARAMETER_NAMES}
     theta_vel = jnp.array([vel_pars[k] for k in vel_model.PARAMETER_NAMES])
-    model_vel = vel_model.render(theta_vel, "image", image_pars_vel)
+    model_vel = vel_model.render(theta_vel, 'image', image_pars_vel)
 
     # Evaluate intensity model
     int_model = task.model.intensity_model
     int_pars = {k: full_pars[k] for k in int_model.PARAMETER_NAMES}
     theta_int = jnp.array([int_pars[k] for k in int_model.PARAMETER_NAMES])
-    model_int = int_model.render(theta_int, "image", image_pars_int)
+    model_int = int_model.render(theta_int, 'image', image_pars_int)
 
     return model_vel, model_int
 
@@ -466,20 +466,20 @@ def run_tng_sampling_test(
     # Combine with geometric true_pars
     full_true_pars = {**true_pars, **vel_params, **int_params}
 
-    print(f"\n{'=' * 60}")
-    print(f"TNG Sampling: SubhaloID {subhalo_id} - {test_name}")
-    print(f"{'=' * 60}")
+    print(f'\n{"=" * 60}')
+    print(f'TNG Sampling: SubhaloID {subhalo_id} - {test_name}')
+    print(f'{"=" * 60}')
     print(
-        f"Geometric params: cosi={true_pars['cosi']:.3f}, theta_int={true_pars['theta_int']:.3f}"
+        f'Geometric params: cosi={true_pars["cosi"]:.3f}, theta_int={true_pars["theta_int"]:.3f}'
     )
     print(
-        f"Estimated velocity: v0={vel_params['v0']:.1f}, vcirc={vel_params['vcirc']:.1f}, "
-        f"vel_rscale={vel_params['vel_rscale']:.2f}"
+        f'Estimated velocity: v0={vel_params["v0"]:.1f}, vcirc={vel_params["vcirc"]:.1f}, '
+        f'vel_rscale={vel_params["vel_rscale"]:.2f}'
     )
     print(
-        f"Estimated intensity: flux={int_params['flux']:.2f}, int_rscale={int_params['int_rscale']:.2f}"
+        f'Estimated intensity: flux={int_params["flux"]:.2f}, int_rscale={int_params["int_rscale"]:.2f}'
     )
-    print(f"Variance (mean): vel={var_vel_mean:.2e}, int={var_int_mean:.2e}")
+    print(f'Variance (mean): vel={var_vel_mean:.2e}, int={var_int_mean:.2e}')
 
     # Create inference task
     data_vel = jnp.array(velocity_raw)
@@ -495,8 +495,8 @@ def run_tng_sampling_test(
         image_pars,
     )
 
-    print(f"Sampled parameters: {task.sampled_names}")
-    print(f"Fixed parameters: {list(task.fixed_params.keys())}")
+    print(f'Sampled parameters: {task.sampled_names}')
+    print(f'Fixed parameters: {list(task.fixed_params.keys())}')
 
     # Configure numpyro sampler with settings balanced for speed and quality
     # Given model mismatch, we prioritize getting reasonable diagnostics over perfect convergence
@@ -504,24 +504,24 @@ def run_tng_sampling_test(
         n_samples=N_SAMPLES,
         n_warmup=N_WARMUP,
         n_chains=N_CHAINS,
-        chain_method="vectorized",
+        chain_method='vectorized',
         seed=seed,
         progress=True,  # Show progress so we can see what's happening
-        reparam_strategy="prior",
+        reparam_strategy='prior',
         dense_mass=False,  # Diagonal mass matrix is faster and often sufficient
         max_tree_depth=8,  # Limit tree depth to prevent very long iterations
         target_accept_prob=0.8,  # Standard acceptance target
     )
 
     # Run sampler
-    sampler = build_sampler("numpyro", task, numpyro_config)
+    sampler = build_sampler('numpyro', task, numpyro_config)
     start_time = time.time()
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+        warnings.simplefilter('ignore')
         result = sampler.run()
     runtime = time.time() - start_time
 
-    print(f"Sampling complete: {result.n_samples} samples in {runtime:.1f}s")
+    print(f'Sampling complete: {result.n_samples} samples in {runtime:.1f}s')
 
     # Get MAP estimate
     map_pars = get_map_from_samples(result)
@@ -531,14 +531,14 @@ def run_tng_sampling_test(
 
     # Save corner plot
     sampler_info = {
-        "name": "numpyro",
-        "runtime": runtime,
-        "settings": {
-            "n_samples": N_SAMPLES,
-            "n_warmup": N_WARMUP,
-            "n_chains": N_CHAINS,
-            "SNR": snr,
-            "SubhaloID": subhalo_id,
+        'name': 'numpyro',
+        'runtime': runtime,
+        'settings': {
+            'n_samples': N_SAMPLES,
+            'n_warmup': N_WARMUP,
+            'n_chains': N_CHAINS,
+            'SNR': snr,
+            'SubhaloID': subhalo_id,
         },
     }
 
@@ -553,10 +553,10 @@ def run_tng_sampling_test(
         map_values=map_pars,
         sampler_info=sampler_info,
     )
-    corner_path = output_dir / f"{test_name}_subhalo{subhalo_id}_corner.png"
-    fig.savefig(corner_path, dpi=150, bbox_inches="tight")
+    corner_path = output_dir / f'{test_name}_subhalo{subhalo_id}_corner.png'
+    fig.savefig(corner_path, dpi=150, bbox_inches='tight')
     plt.close(fig)
-    print(f"Saved corner plot: {corner_path}")
+    print(f'Saved corner plot: {corner_path}')
 
     # Save data comparison panels
     # Use the noisy data as both "noisy" and "true" since TNG is the "truth"
@@ -567,25 +567,25 @@ def run_tng_sampling_test(
         data_int_noisy=np.asarray(data_int),
         data_int_true=np.asarray(data_int),  # TNG is truth
         model_int=np.asarray(model_int),
-        test_name=f"{test_name}_subhalo{subhalo_id}",
+        test_name=f'{test_name}_subhalo{subhalo_id}',
         output_dir=output_dir,
         variance_vel=var_vel_mean,
         variance_int=var_int_mean,
         n_params=task.n_params,
-        model_label="MAP Model",
+        model_label='MAP Model',
     )
-    print(f"Saved data comparison: {test_name}_subhalo{subhalo_id}_data_comparison.png")
+    print(f'Saved data comparison: {test_name}_subhalo{subhalo_id}_data_comparison.png')
 
     # Print summary
     print_summary(result, true_values=corner_true_values)
 
     return {
-        "runtime": runtime,
-        "result": result,
-        "map_pars": map_pars,
-        "true_pars": full_true_pars,
-        "model_vel": model_vel,
-        "model_int": model_int,
+        'runtime': runtime,
+        'result': result,
+        'map_pars': map_pars,
+        'true_pars': full_true_pars,
+        'model_vel': model_vel,
+        'model_int': model_int,
     }
 
 
@@ -601,7 +601,7 @@ class TestTNGNativeSampling:
     Uses TNG catalog inclination and position angle as "true" geometric params.
     """
 
-    @pytest.mark.parametrize("subhalo_id", TEST_SUBHALO_IDS)
+    @pytest.mark.parametrize('subhalo_id', TEST_SUBHALO_IDS)
     def test_native_orientation_sampling(
         self, tng_data, output_dir, image_pars, subhalo_id
     ):
@@ -617,22 +617,22 @@ class TestTNGNativeSampling:
 
         # Extract native orientation as "true" geometric parameters
         true_pars = {
-            "cosi": gen.native_cosi,
-            "theta_int": gen.native_pa_rad,
-            "g1": 0.0,
-            "g2": 0.0,
+            'cosi': gen.native_cosi,
+            'theta_int': gen.native_pa_rad,
+            'g1': 0.0,
+            'g2': 0.0,
         }
 
         print(
-            f"\nNative orientation: inc={gen.native_inclination_deg:.1f}°, "
-            f"PA={gen.native_pa_deg:.1f}°"
+            f'\nNative orientation: inc={gen.native_inclination_deg:.1f}°, '
+            f'PA={gen.native_pa_deg:.1f}°'
         )
-        print(f"  -> cosi={gen.native_cosi:.3f}, theta_int={gen.native_pa_rad:.3f} rad")
+        print(f'  -> cosi={gen.native_cosi:.3f}, theta_int={gen.native_pa_rad:.3f} rad')
 
         # Create render config for native orientation
         config = TNGRenderConfig(
             image_pars=image_pars,
-            band="r",
+            band='r',
             use_native_orientation=True,
             target_redshift=TARGET_REDSHIFT,
             use_cic_gridding=True,
@@ -644,7 +644,7 @@ class TestTNGNativeSampling:
             subhalo_id=subhalo_id,
             config=config,
             true_pars=true_pars,
-            test_name="native",
+            test_name='native',
             output_dir=output_dir,
             image_pars=image_pars,
             snr=DEFAULT_SNR,
@@ -652,9 +652,9 @@ class TestTNGNativeSampling:
         )
 
         # Basic assertions
-        assert results["result"].n_samples > 0
-        assert results["runtime"] > 0
-        assert all(np.isfinite(results["result"].log_prob))
+        assert results['result'].n_samples > 0
+        assert results['runtime'] > 0
+        assert all(np.isfinite(results['result'].log_prob))
 
 
 class TestTNGCustomSampling:
@@ -669,7 +669,7 @@ class TestTNGCustomSampling:
     CUSTOM_PA_DEG = 30.0
     CUSTOM_COSI = 0.5
 
-    @pytest.mark.parametrize("subhalo_id", TEST_SUBHALO_IDS)
+    @pytest.mark.parametrize('subhalo_id', TEST_SUBHALO_IDS)
     def test_custom_orientation_sampling(
         self, tng_data, output_dir, image_pars, subhalo_id
     ):
@@ -685,26 +685,26 @@ class TestTNGCustomSampling:
         # Custom geometric parameters
         theta_int = np.radians(self.CUSTOM_PA_DEG)
         true_pars = {
-            "cosi": self.CUSTOM_COSI,
-            "theta_int": theta_int,
-            "g1": 0.0,
-            "g2": 0.0,
-            "x0": 0.0,
-            "y0": 0.0,
+            'cosi': self.CUSTOM_COSI,
+            'theta_int': theta_int,
+            'g1': 0.0,
+            'g2': 0.0,
+            'x0': 0.0,
+            'y0': 0.0,
         }
 
         print(
-            f"\nCustom orientation: inc={np.degrees(np.arccos(self.CUSTOM_COSI)):.1f}°, "
-            f"PA={self.CUSTOM_PA_DEG:.1f}°"
+            f'\nCustom orientation: inc={np.degrees(np.arccos(self.CUSTOM_COSI)):.1f}°, '
+            f'PA={self.CUSTOM_PA_DEG:.1f}°'
         )
-        print(f"  -> cosi={self.CUSTOM_COSI:.3f}, theta_int={theta_int:.3f} rad")
-        print(f"  -> preserve_gas_stellar_offset=False (aligned geometry)")
+        print(f'  -> cosi={self.CUSTOM_COSI:.3f}, theta_int={theta_int:.3f} rad')
+        print(f'  -> preserve_gas_stellar_offset=False (aligned geometry)')
 
         # Create render config with custom orientation and aligned gas/stellar
-        pars = {k: true_pars[k] for k in ["cosi", "theta_int", "x0", "y0", "g1", "g2"]}
+        pars = {k: true_pars[k] for k in ['cosi', 'theta_int', 'x0', 'y0', 'g1', 'g2']}
         config = TNGRenderConfig(
             image_pars=image_pars,
-            band="r",
+            band='r',
             use_native_orientation=False,
             pars=pars,
             target_redshift=TARGET_REDSHIFT,
@@ -718,7 +718,7 @@ class TestTNGCustomSampling:
             subhalo_id=subhalo_id,
             config=config,
             true_pars=true_pars,
-            test_name="custom_aligned",
+            test_name='custom_aligned',
             output_dir=output_dir,
             image_pars=image_pars,
             snr=DEFAULT_SNR,
@@ -726,21 +726,21 @@ class TestTNGCustomSampling:
         )
 
         # Basic assertions
-        assert results["result"].n_samples > 0
-        assert results["runtime"] > 0
-        assert all(np.isfinite(results["result"].log_prob))
+        assert results['result'].n_samples > 0
+        assert results['runtime'] > 0
+        assert all(np.isfinite(results['result'].log_prob))
 
         # Additional check: cosi should be recovered near true value
         # (with aligned geometry, model should fit better)
-        map_cosi = results["map_pars"].get("cosi", 0)
+        map_cosi = results['map_pars'].get('cosi', 0)
         cosi_error = abs(map_cosi - self.CUSTOM_COSI)
         print(
-            f"cosi recovery: true={self.CUSTOM_COSI:.3f}, MAP={map_cosi:.3f}, "
-            f"error={cosi_error:.3f}"
+            f'cosi recovery: true={self.CUSTOM_COSI:.3f}, MAP={map_cosi:.3f}, '
+            f'error={cosi_error:.3f}'
         )
 
         # Warn if recovery is poor (not fail - TNG doesn't match model exactly)
         if cosi_error > 0.3:
             warnings.warn(
-                f"Poor cosi recovery for SubhaloID {subhalo_id}: error={cosi_error:.3f}"
+                f'Poor cosi recovery for SubhaloID {subhalo_id}: error={cosi_error:.3f}'
             )

--- a/tests/test_tng_sampling_diagnostics.py
+++ b/tests/test_tng_sampling_diagnostics.py
@@ -58,7 +58,12 @@ pytestmark = [pytest.mark.tng50, pytest.mark.tng_diagnostics, pytest.mark.slow]
 # ==============================================================================
 
 # Galaxies to test
-TEST_SUBHALO_IDS = [8, 19, 29]
+# TEST_SUBHALO_IDS = [8, 19, 29]
+TEST_SUBHALO_IDS = [
+    184941,
+    229935,
+    294869,
+]  # Use index=0 galaxy for testing to avoid SubhaloID issues
 
 # Standard image parameters - smaller for faster likelihood evaluation
 IMAGE_SHAPE = (32, 32)  # 1024 pixels instead of 4096
@@ -102,7 +107,7 @@ def output_dir():
 @pytest.fixture
 def image_pars():
     """Standard test image parameters."""
-    return ImagePars(shape=IMAGE_SHAPE, pixel_scale=PIXEL_SCALE, indexing='ij')
+    return ImagePars(shape=IMAGE_SHAPE, pixel_scale=PIXEL_SCALE, indexing="ij")
 
 
 # ==============================================================================
@@ -134,7 +139,7 @@ def estimate_velocity_params(
 
     if valid_mask.sum() < 10:
         # Not enough valid pixels, return defaults
-        return {'v0': 0.0, 'vcirc': 150.0, 'vel_rscale': 0.5}
+        return {"v0": 0.0, "vcirc": 150.0, "vel_rscale": 0.5}
 
     valid_vel = velocity_map[valid_mask]
 
@@ -157,11 +162,11 @@ def estimate_velocity_params(
     vel_rscale = fov_arcsec / 6.0  # Rough estimate
 
     return {
-        'v0': v0,
-        'vcirc': vcirc_estimate,
-        'vel_rscale': vel_rscale,
-        'vel_x0': 0.0,  # Assume centered initially
-        'vel_y0': 0.0,
+        "v0": v0,
+        "vcirc": vcirc_estimate,
+        "vel_rscale": vel_rscale,
+        "vel_x0": 0.0,  # Assume centered initially
+        "vel_y0": 0.0,
     }
 
 
@@ -220,11 +225,11 @@ def estimate_intensity_params(
     total = intensity_map.sum()
     if total <= 0:
         return {
-            'flux': flux,
-            'int_rscale': 0.5,
-            'int_h_over_r': 0.1,
-            'int_x0': 0.0,
-            'int_y0': 0.0,
+            "flux": flux,
+            "int_rscale": 0.5,
+            "int_h_over_r": 0.1,
+            "int_x0": 0.0,
+            "int_y0": 0.0,
         }
 
     cumsum = np.cumsum(np.sort(intensity_map.ravel())[::-1])
@@ -241,11 +246,11 @@ def estimate_intensity_params(
     int_rscale = max(0.1, min(3.0, int_rscale))
 
     return {
-        'flux': flux,
-        'int_rscale': int_rscale,
-        'int_h_over_r': 0.1,
-        'int_x0': 0.0,
-        'int_y0': 0.0,
+        "flux": flux,
+        "int_rscale": int_rscale,
+        "int_h_over_r": 0.1,
+        "int_x0": 0.0,
+        "int_y0": 0.0,
     }
 
 
@@ -286,7 +291,7 @@ def create_tng_joint_inference_task(
     joint_model = KLModel(
         velocity_model=vel_model,
         intensity_model=int_model,
-        shared_pars={'cosi', 'theta_int', 'g1', 'g2'},
+        shared_pars={"cosi", "theta_int", "g1", "g2"},
     )
 
     # FOV for offset prior bounds
@@ -297,36 +302,39 @@ def create_tng_joint_inference_task(
     # This allows exploration since TNG doesn't match analytic models exactly
     prior_spec = {
         # Velocity params - wide priors
-        'v0': Gaussian(true_pars.get('v0', 0.0), 30.0),  # Wide Gaussian
-        'vcirc': TruncatedNormal(
-            true_pars.get('vcirc', 150.0), 100.0, 30, 500
+        "v0": Gaussian(true_pars.get("v0", 0.0), 30.0),  # Wide Gaussian
+        "vcirc": TruncatedNormal(
+            true_pars.get("vcirc", 150.0), 100.0, 30, 500
         ),  # Very wide
-        'vel_rscale': TruncatedNormal(true_pars.get('vel_rscale', 0.5), 0.5, 0.05, 3.0),
-        'vel_x0': TruncatedNormal(
-            true_pars.get('vel_x0', 0.0), 0.5, -offset_bound, offset_bound
+        "vel_rscale": TruncatedNormal(true_pars.get("vel_rscale", 0.5), 0.5, 0.05, 3.0),
+        "vel_x0": TruncatedNormal(
+            true_pars.get("vel_x0", 0.0), 0.5, -offset_bound, offset_bound
         ),
-        'vel_y0': TruncatedNormal(
-            true_pars.get('vel_y0', 0.0), 0.5, -offset_bound, offset_bound
+        "vel_y0": TruncatedNormal(
+            true_pars.get("vel_y0", 0.0), 0.5, -offset_bound, offset_bound
         ),
         # Intensity params - wide priors
         # After normalization, flux ~0.01 gives unit integrated flux in model
-        'flux': TruncatedNormal(true_pars.get('flux', 0.01), 0.02, 0.001, 0.1),
-        'int_rscale': TruncatedNormal(true_pars.get('int_rscale', 0.5), 0.5, 0.05, 3.0),
-        'int_h_over_r': 0.1,  # Fixed
-        'int_x0': TruncatedNormal(
-            true_pars.get('int_x0', 0.0), 0.5, -offset_bound, offset_bound
+        "flux": TruncatedNormal(true_pars.get("flux", 0.01), 0.02, 0.001, 0.1),
+        "int_rscale": TruncatedNormal(true_pars.get("int_rscale", 0.5), 0.5, 0.05, 3.0),
+        "int_h_over_r": 0.1,  # Fixed
+        "int_x0": TruncatedNormal(
+            true_pars.get("int_x0", 0.0), 0.5, -offset_bound, offset_bound
         ),
-        'int_y0': TruncatedNormal(
-            true_pars.get('int_y0', 0.0), 0.5, -offset_bound, offset_bound
+        "int_y0": TruncatedNormal(
+            true_pars.get("int_y0", 0.0), 0.5, -offset_bound, offset_bound
         ),
         # Shared geometric params - centered on known TNG values
-        'cosi': TruncatedNormal(true_pars['cosi'], 0.2, 0.01, 0.99),
-        'theta_int': TruncatedNormal(
-            true_pars['theta_int'], 0.5, 0.0, 2 * np.pi  # Full 0-2pi range
+        "cosi": TruncatedNormal(true_pars["cosi"], 0.2, 0.01, 0.99),
+        "theta_int": TruncatedNormal(
+            true_pars["theta_int"],
+            0.5,
+            0.0,
+            2 * np.pi,  # Full 0-2pi range
         ),
         # No shear for TNG (unlensed)
-        'g1': 0.0,
-        'g2': 0.0,
+        "g1": 0.0,
+        "g2": 0.0,
     }
 
     priors = PriorDict(prior_spec)
@@ -375,13 +383,13 @@ def evaluate_model_at_map(
     vel_model = task.model.velocity_model
     vel_pars = {k: full_pars[k] for k in vel_model.PARAMETER_NAMES}
     theta_vel = jnp.array([vel_pars[k] for k in vel_model.PARAMETER_NAMES])
-    model_vel = vel_model.render(theta_vel, 'image', image_pars_vel)
+    model_vel = vel_model.render(theta_vel, "image", image_pars_vel)
 
     # Evaluate intensity model
     int_model = task.model.intensity_model
     int_pars = {k: full_pars[k] for k in int_model.PARAMETER_NAMES}
     theta_int = jnp.array([int_pars[k] for k in int_model.PARAMETER_NAMES])
-    model_int = int_model.render(theta_int, 'image', image_pars_int)
+    model_int = int_model.render(theta_int, "image", image_pars_int)
 
     return model_vel, model_int
 
@@ -458,9 +466,9 @@ def run_tng_sampling_test(
     # Combine with geometric true_pars
     full_true_pars = {**true_pars, **vel_params, **int_params}
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"TNG Sampling: SubhaloID {subhalo_id} - {test_name}")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
     print(
         f"Geometric params: cosi={true_pars['cosi']:.3f}, theta_int={true_pars['theta_int']:.3f}"
     )
@@ -496,17 +504,17 @@ def run_tng_sampling_test(
         n_samples=N_SAMPLES,
         n_warmup=N_WARMUP,
         n_chains=N_CHAINS,
-        chain_method='vectorized',
+        chain_method="vectorized",
         seed=seed,
         progress=True,  # Show progress so we can see what's happening
-        reparam_strategy='prior',
+        reparam_strategy="prior",
         dense_mass=False,  # Diagonal mass matrix is faster and often sufficient
         max_tree_depth=8,  # Limit tree depth to prevent very long iterations
         target_accept_prob=0.8,  # Standard acceptance target
     )
 
     # Run sampler
-    sampler = build_sampler('numpyro', task, numpyro_config)
+    sampler = build_sampler("numpyro", task, numpyro_config)
     start_time = time.time()
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -523,14 +531,14 @@ def run_tng_sampling_test(
 
     # Save corner plot
     sampler_info = {
-        'name': 'numpyro',
-        'runtime': runtime,
-        'settings': {
-            'n_samples': N_SAMPLES,
-            'n_warmup': N_WARMUP,
-            'n_chains': N_CHAINS,
-            'SNR': snr,
-            'SubhaloID': subhalo_id,
+        "name": "numpyro",
+        "runtime": runtime,
+        "settings": {
+            "n_samples": N_SAMPLES,
+            "n_warmup": N_WARMUP,
+            "n_chains": N_CHAINS,
+            "SNR": snr,
+            "SubhaloID": subhalo_id,
         },
     }
 
@@ -546,7 +554,7 @@ def run_tng_sampling_test(
         sampler_info=sampler_info,
     )
     corner_path = output_dir / f"{test_name}_subhalo{subhalo_id}_corner.png"
-    fig.savefig(corner_path, dpi=150, bbox_inches='tight')
+    fig.savefig(corner_path, dpi=150, bbox_inches="tight")
     plt.close(fig)
     print(f"Saved corner plot: {corner_path}")
 
@@ -564,7 +572,7 @@ def run_tng_sampling_test(
         variance_vel=var_vel_mean,
         variance_int=var_int_mean,
         n_params=task.n_params,
-        model_label='MAP Model',
+        model_label="MAP Model",
     )
     print(f"Saved data comparison: {test_name}_subhalo{subhalo_id}_data_comparison.png")
 
@@ -572,12 +580,12 @@ def run_tng_sampling_test(
     print_summary(result, true_values=corner_true_values)
 
     return {
-        'runtime': runtime,
-        'result': result,
-        'map_pars': map_pars,
-        'true_pars': full_true_pars,
-        'model_vel': model_vel,
-        'model_int': model_int,
+        "runtime": runtime,
+        "result": result,
+        "map_pars": map_pars,
+        "true_pars": full_true_pars,
+        "model_vel": model_vel,
+        "model_int": model_int,
     }
 
 
@@ -609,10 +617,10 @@ class TestTNGNativeSampling:
 
         # Extract native orientation as "true" geometric parameters
         true_pars = {
-            'cosi': gen.native_cosi,
-            'theta_int': gen.native_pa_rad,
-            'g1': 0.0,
-            'g2': 0.0,
+            "cosi": gen.native_cosi,
+            "theta_int": gen.native_pa_rad,
+            "g1": 0.0,
+            "g2": 0.0,
         }
 
         print(
@@ -624,7 +632,7 @@ class TestTNGNativeSampling:
         # Create render config for native orientation
         config = TNGRenderConfig(
             image_pars=image_pars,
-            band='r',
+            band="r",
             use_native_orientation=True,
             target_redshift=TARGET_REDSHIFT,
             use_cic_gridding=True,
@@ -644,9 +652,9 @@ class TestTNGNativeSampling:
         )
 
         # Basic assertions
-        assert results['result'].n_samples > 0
-        assert results['runtime'] > 0
-        assert all(np.isfinite(results['result'].log_prob))
+        assert results["result"].n_samples > 0
+        assert results["runtime"] > 0
+        assert all(np.isfinite(results["result"].log_prob))
 
 
 class TestTNGCustomSampling:
@@ -677,12 +685,12 @@ class TestTNGCustomSampling:
         # Custom geometric parameters
         theta_int = np.radians(self.CUSTOM_PA_DEG)
         true_pars = {
-            'cosi': self.CUSTOM_COSI,
-            'theta_int': theta_int,
-            'g1': 0.0,
-            'g2': 0.0,
-            'x0': 0.0,
-            'y0': 0.0,
+            "cosi": self.CUSTOM_COSI,
+            "theta_int": theta_int,
+            "g1": 0.0,
+            "g2": 0.0,
+            "x0": 0.0,
+            "y0": 0.0,
         }
 
         print(
@@ -693,10 +701,10 @@ class TestTNGCustomSampling:
         print(f"  -> preserve_gas_stellar_offset=False (aligned geometry)")
 
         # Create render config with custom orientation and aligned gas/stellar
-        pars = {k: true_pars[k] for k in ['cosi', 'theta_int', 'x0', 'y0', 'g1', 'g2']}
+        pars = {k: true_pars[k] for k in ["cosi", "theta_int", "x0", "y0", "g1", "g2"]}
         config = TNGRenderConfig(
             image_pars=image_pars,
-            band='r',
+            band="r",
             use_native_orientation=False,
             pars=pars,
             target_redshift=TARGET_REDSHIFT,
@@ -718,13 +726,13 @@ class TestTNGCustomSampling:
         )
 
         # Basic assertions
-        assert results['result'].n_samples > 0
-        assert results['runtime'] > 0
-        assert all(np.isfinite(results['result'].log_prob))
+        assert results["result"].n_samples > 0
+        assert results["runtime"] > 0
+        assert all(np.isfinite(results["result"].log_prob))
 
         # Additional check: cosi should be recovered near true value
         # (with aligned geometry, model should fit better)
-        map_cosi = results['map_pars'].get('cosi', 0)
+        map_cosi = results["map_pars"].get("cosi", 0)
         cosi_error = abs(map_cosi - self.CUSTOM_COSI)
         print(
             f"cosi recovery: true={self.CUSTOM_COSI:.3f}, MAP={map_cosi:.3f}, "
@@ -734,6 +742,5 @@ class TestTNGCustomSampling:
         # Warn if recovery is poor (not fail - TNG doesn't match model exactly)
         if cosi_error > 0.3:
             warnings.warn(
-                f"Poor cosi recovery for SubhaloID {subhalo_id}: "
-                f"error={cosi_error:.3f}"
+                f"Poor cosi recovery for SubhaloID {subhalo_id}: error={cosi_error:.3f}"
             )


### PR DESCRIPTION
I have implemented the dust attenuation model that was used to generate the TNG spiral galaxy catalogues. This will calculate the dust attenuation models for a user-specified arbitrary orientation. To do this, we also need to download the SED grid and the filter response functions since the dust attenuation correction is wavelength-dependent. Additionally, the units in the output TNG catalogue are already in physical units, so I have removed all unnecessary unit conversions. Lastly, I have implemented two new tests to ensure the dust attenuation function is working as intended. The outcome of this PR will also fix the following issues:

Fixes #37 #36 #35 