### PR TITLE
Roman PSF for Ensemble Test

### DIFF
--- a/configs/observing/canonical_P_roman.yaml
+++ b/configs/observing/canonical_P_roman.yaml
@@ -1,12 +1,13 @@
 # Flagship-P structural observing config with the realistic Roman WFI PSF
-# (galsim.roman.getPSF, monochromatic): 2 broadbands (H158 + F184, real WFI
-# bandpasses) + 4 grism rolls (0/45/90/135 deg), single Halpha line. Same
-# roll/stamp/render geometry as canonical_P. Broadband PSFs are evaluated at
-# each band's effective wavelength; the grism PSF at the observed Halpha
-# wavelength (z-dependent), with the kernel stamp pinned at the ensemble's
-# largest observed wavelength so the PSF array shape is constant across fits.
+# (galsim.roman.getPSF, monochromatic): 2 broadbands (F158 + F184, official
+# Roman WFI filter names; galsim maps F158 to its legacy key H158) + 4 grism
+# rolls (0/45/90/135 deg), single Halpha line. Same roll/stamp/render
+# geometry as canonical_P. Broadband PSFs are evaluated at each band's
+# effective wavelength; the grism PSF at the observed Halpha wavelength
+# (z-dependent), with the kernel stamp pinned at the ensemble's largest
+# observed wavelength so the PSF array shape is constant across fits.
 id: canonical_P_roman
-bands: [H158, F184]
+bands: [F158, F184]
 grism:
   rolls_deg: [0.0, 45.0, 90.0, 135.0]
   dispersion_nm_per_pix: 1.1

--- a/configs/observing/canonical_P_roman.yaml
+++ b/configs/observing/canonical_P_roman.yaml
@@ -12,9 +12,14 @@ grism:
   rolls_deg: [0.0, 45.0, 90.0, 135.0]
   dispersion_nm_per_pix: 1.1
 lines: [Halpha]
+# folding_threshold 0.01 applies to the FIT kernels only (2.8x cheaper
+# evals; parameter-level bias gated at <= 0.07 sigma vs matched kernels);
+# mock/truth renders keep the galsim default 5e-3 kernels
+# (mock_folding_threshold unset), so mock data is always rendered at higher
+# kernel fidelity than the inference model.
 psf:
-  broadband: {type: roman_wfi, sca: 10, pupil_bin: 4}
-  grism: {type: roman_wfi, sca: 10, pupil_bin: 4}
+  broadband: {type: roman_wfi, sca: 10, pupil_bin: 4, folding_threshold: 0.01}
+  grism: {type: roman_wfi, sca: 10, pupil_bin: 4, folding_threshold: 0.01}
 pixel_scale_arcsec: 0.11
 stamp: {broadband_pix: 32, grism_pix: 32}
 render: {oversample: 3}

--- a/configs/observing/canonical_P_roman.yaml
+++ b/configs/observing/canonical_P_roman.yaml
@@ -1,0 +1,19 @@
+# Flagship-P structural observing config with the realistic Roman WFI PSF
+# (galsim.roman.getPSF, monochromatic): 2 broadbands (H158 + F184, real WFI
+# bandpasses) + 4 grism rolls (0/45/90/135 deg), single Halpha line. Same
+# roll/stamp/render geometry as canonical_P. Broadband PSFs are evaluated at
+# each band's effective wavelength; the grism PSF at the observed Halpha
+# wavelength (z-dependent), with the kernel stamp pinned at the ensemble's
+# largest observed wavelength so the PSF array shape is constant across fits.
+id: canonical_P_roman
+bands: [H158, F184]
+grism:
+  rolls_deg: [0.0, 45.0, 90.0, 135.0]
+  dispersion_nm_per_pix: 1.1
+lines: [Halpha]
+psf:
+  broadband: {type: roman_wfi, sca: 10, pupil_bin: 4}
+  grism: {type: roman_wfi, sca: 10, pupil_bin: 4}
+pixel_scale_arcsec: 0.11
+stamp: {broadband_pix: 32, grism_pix: 32}
+render: {oversample: 3}

--- a/configs/observing/canonical_P_roman.yaml
+++ b/configs/observing/canonical_P_roman.yaml
@@ -12,14 +12,26 @@ grism:
   rolls_deg: [0.0, 45.0, 90.0, 135.0]
   dispersion_nm_per_pix: 1.1
 lines: [Halpha]
-# folding_threshold 0.01 applies to the FIT kernels only (2.8x cheaper
-# evals; parameter-level bias gated at <= 0.07 sigma vs matched kernels);
-# mock/truth renders keep the galsim default 5e-3 kernels
-# (mock_folding_threshold unset), so mock data is always rendered at higher
-# kernel fidelity than the inference model.
+# FIT-kernel folding_threshold follows a z-tiered schedule (fit kernels only;
+# mock/truth renders keep the galsim default 5e-3 kernels, mock_folding_threshold
+# unset). The rigor audit found the ft=0.01 acceptance does not extend across z:
+# wing-truncation bias grows monotonically with kernel size and exceeds the
+# z<=1.2 envelope by z=1.9. User ruling: ft=0.01 for z<=1.2, tighter ft=5e-3
+# above -- at the tight tier ft == the mock default 5e-3, so mock == fit by
+# construction (zero mock/fit kernel mismatch). Measured cost of the schedule
+# with the rfft2 + minimal-padding psf patch: ensemble-mean ~1.27x, per-eval
+# 1.56x at z=1.9; z<=1.2 scenes resolve ft=0.01 (unchanged cost).
 psf:
-  broadband: {type: roman_wfi, sca: 10, pupil_bin: 4, folding_threshold: 0.01}
-  grism: {type: roman_wfi, sca: 10, pupil_bin: 4, folding_threshold: 0.01}
+  broadband:
+    type: roman_wfi
+    sca: 10
+    pupil_bin: 4
+    folding_threshold_tiers: [{z_max: 1.2, ft: 0.01}, {z_max: null, ft: 5.0e-3}]
+  grism:
+    type: roman_wfi
+    sca: 10
+    pupil_bin: 4
+    folding_threshold_tiers: [{z_max: 1.2, ft: 0.01}, {z_max: null, ft: 5.0e-3}]
 pixel_scale_arcsec: 0.11
 stamp: {broadband_pix: 32, grism_pix: 32}
 render: {oversample: 3}

--- a/kl_pipe/ensemble/README.md
+++ b/kl_pipe/ensemble/README.md
@@ -92,7 +92,8 @@ scene.py        canonical galaxy scene: truth defaults + fit prior rules
 expander.py     spec -> manifest.parquet (deterministic seeds, CRN rule,
                 fit_id, provenance snapshot)
 mocks.py        truth row -> noisy mock observations (model-rendered,
-                matched-filter noise, galsim Gaussian PSFs)
+                matched-filter noise; PSF per config: galsim Gaussian or
+                Roman WFI via galsim.roman.getPSF, z-dependent grism kernel)
 worker.py       claim -> mock -> NUTS (Laplace precond, PA-stratified MAP
                 starts, one retry on broken chains) -> per-fit parquet
 ledger.py       lock-free filesystem status (atomic-mkdir claims,

--- a/kl_pipe/ensemble/__init__.py
+++ b/kl_pipe/ensemble/__init__.py
@@ -22,6 +22,6 @@ python -m kl_pipe.ensemble status --run-dir runs/<run_name>
 python -m kl_pipe.ensemble collate --run-dir runs/<run_name>
 """
 
-from kl_pipe.ensemble.spec import EnsembleSpec, ObservingConfig
+from kl_pipe.ensemble.spec import EnsembleSpec, ObservingConfig, PSFSpec
 
-__all__ = ['EnsembleSpec', 'ObservingConfig']
+__all__ = ['EnsembleSpec', 'ObservingConfig', 'PSFSpec']

--- a/kl_pipe/ensemble/mocks.py
+++ b/kl_pipe/ensemble/mocks.py
@@ -78,8 +78,12 @@ def _build_gaussian_psf(fwhm_arcsec: float):
 
 # process-level cache: getPSF is expensive (~0.5 s) and the worker builds
 # several obs per fit (bands + rolls) plus the pinned-size reference PSF, so
-# repeated wavelengths must not re-run the optics computation
+# repeated wavelengths must not re-run the optics computation. Bounded FIFO:
+# a long-lived worker claims many fits at distinct redshifts, so an unbounded
+# cache would accumulate one GSObject per fit; within-fit reuse only needs a
+# handful of entries.
 _ROMAN_PSF_CACHE: Dict[Tuple[int, int, float, Optional[str]], object] = {}
+_ROMAN_PSF_CACHE_MAX = 16
 
 
 def _get_roman_wfi_psf(
@@ -109,6 +113,8 @@ def _get_roman_wfi_psf(
 
     key = (int(sca), int(pupil_bin), round(float(wavelength_nm), 1), bandpass)
     if key not in _ROMAN_PSF_CACHE:
+        while len(_ROMAN_PSF_CACHE) >= _ROMAN_PSF_CACHE_MAX:
+            _ROMAN_PSF_CACHE.pop(next(iter(_ROMAN_PSF_CACHE)))
         _ROMAN_PSF_CACHE[key] = roman.getPSF(
             SCA=key[0], bandpass=bandpass, wavelength=key[2], pupil_bin=key[1]
         )

--- a/kl_pipe/ensemble/mocks.py
+++ b/kl_pipe/ensemble/mocks.py
@@ -15,15 +15,21 @@ Per-channel noise seeds are derived from the manifest row's ``noise_seed``
 via a SeedSequence spawn, so a single integer in the manifest reproduces the
 whole multi-channel realization.
 
-PSFs are galsim.Gaussian in v1 (the complex WFI grism PSF is a known pending
-gap). On hosts without galsim (e.g. Vista NGC containers), the vista_kit
-GaussianPSFShim mechanism applies; this module raises a clear ImportError
-rather than silently substituting.
+PSFs are built per channel from the observing config's ``PSFSpec``:
+``gaussian`` (galsim.Gaussian at the configured FWHM) or ``roman_wfi``
+(monochromatic ``galsim.roman.getPSF``; broadband at the band's effective
+wavelength, grism at the observed Halpha wavelength). Roman grism kernels
+are rendered at a stamp size pinned to the ensemble's largest observed
+wavelength so the PSF array shape is constant across z. On hosts without
+galsim (e.g. Vista NGC containers), the vista_kit GaussianPSFShim mechanism
+applies; this module raises a clear ImportError rather than silently
+substituting.
 """
 
 from __future__ import annotations
 
-from typing import Dict, NamedTuple, TYPE_CHECKING
+from functools import lru_cache
+from typing import Dict, NamedTuple, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
 import jax.numpy as jnp
@@ -37,7 +43,7 @@ from kl_pipe.parameters import ImagePars
 from kl_pipe.render import RenderConfig
 
 if TYPE_CHECKING:
-    from kl_pipe.ensemble.spec import EnsembleSpec, ObservingConfig
+    from kl_pipe.ensemble.spec import EnsembleSpec, ObservingConfig, PSFSpec
     from kl_pipe.priors import PriorDict
     from kl_pipe.source import SourceModel
 
@@ -52,7 +58,7 @@ class FitInputs(NamedTuple):
     truth: Dict[str, float]
 
 
-def _build_gaussian_psf(fwhm_arcsec: float):
+def _import_galsim():
     try:
         import galsim
     except ImportError as err:
@@ -62,7 +68,135 @@ def _build_gaussian_psf(fwhm_arcsec: float):
             "stub + GaussianPSFShim before importing kl_pipe (see "
             "experiments/sweverett/vista_kit/psf_numpy.py)."
         ) from err
+    return galsim
+
+
+def _build_gaussian_psf(fwhm_arcsec: float):
+    galsim = _import_galsim()
     return galsim.Gaussian(fwhm=fwhm_arcsec)
+
+
+# process-level cache: getPSF is expensive (~0.5 s) and the worker builds
+# several obs per fit (bands + rolls) plus the pinned-size reference PSF, so
+# repeated wavelengths must not re-run the optics computation
+_ROMAN_PSF_CACHE: Dict[Tuple[int, int, float, Optional[str]], object] = {}
+
+
+def _get_roman_wfi_psf(
+    sca: int, pupil_bin: int, wavelength_nm: float, bandpass: Optional[str]
+):
+    """Monochromatic Roman WFI PSF via galsim.roman.getPSF, cached.
+
+    Cache key rounds the wavelength to 0.1 nm -- far below any PSF-size
+    scale of interest -- so per-fit continuous redshifts still hit the
+    cache across rolls within a fit.
+
+    Parameters
+    ----------
+    sca : int
+        WFI sensor chip assembly (1-18).
+    pupil_bin : int
+        Pupil-plane image binning (galsim.roman.getPSF pupil_bin).
+    wavelength_nm : float
+        Wavelength in nm (galsim.roman.getPSF takes nm).
+    bandpass : str or None
+        Roman bandpass name selecting the pupil-plane configuration
+        (F184 is the only long-wavelength band); None uses the
+        short-wavelength pupil image.
+    """
+    _import_galsim()
+    from galsim import roman
+
+    key = (int(sca), int(pupil_bin), round(float(wavelength_nm), 1), bandpass)
+    if key not in _ROMAN_PSF_CACHE:
+        _ROMAN_PSF_CACHE[key] = roman.getPSF(
+            SCA=key[0], bandpass=bandpass, wavelength=key[2], pupil_bin=key[1]
+        )
+    return _ROMAN_PSF_CACHE[key]
+
+
+@lru_cache(maxsize=None)
+def _band_effective_wavelength_nm(band: str) -> float:
+    """Effective wavelength (nm) of a Roman WFI bandpass."""
+    _import_galsim()
+    from galsim import roman
+
+    bandpasses = roman.getBandpasses()
+    if band not in bandpasses:
+        raise ValueError(
+            f"band '{band}' is not a Roman WFI bandpass; a roman_wfi "
+            f"broadband psf requires one of {sorted(bandpasses)}"
+        )
+    return float(bandpasses[band].effective_wavelength)
+
+
+def _build_band_psf(psf_spec: 'PSFSpec', band: str):
+    """Broadband PSF for one band from its PSFSpec."""
+    if psf_spec.psf_type == 'gaussian':
+        return _build_gaussian_psf(psf_spec.fwhm_arcsec)
+    if psf_spec.psf_type == 'roman_wfi':
+        # monochromatic at the band's effective wavelength; the bandpass
+        # name selects the matching pupil-plane configuration
+        return _get_roman_wfi_psf(
+            psf_spec.sca,
+            psf_spec.pupil_bin,
+            _band_effective_wavelength_nm(band),
+            bandpass=band,
+        )
+    raise NotImplementedError(f"psf type '{psf_spec.psf_type}' has no mock PSF builder")
+
+
+def _build_grism_psf(psf_spec: 'PSFSpec', z: float):
+    """Grism PSF from its PSFSpec, at the observed Halpha wavelength."""
+    if psf_spec.psf_type == 'gaussian':
+        return _build_gaussian_psf(psf_spec.fwhm_arcsec)
+    if psf_spec.psf_type == 'roman_wfi':
+        # monochromatic at the observed line wavelength; bandpass=None uses
+        # the short-wavelength pupil-plane image (galsim.roman does not
+        # model the grism element's own pupil)
+        return _get_roman_wfi_psf(
+            psf_spec.sca,
+            psf_spec.pupil_bin,
+            LINE_LAMBDAS['Halpha'] * (1.0 + z),
+            bandpass=None,
+        )
+    raise NotImplementedError(f"psf type '{psf_spec.psf_type}' has no mock PSF builder")
+
+
+def _grism_psf_kernel_size(
+    config: 'ObservingConfig', spec: 'EnsembleSpec'
+) -> Optional[int]:
+    """Pinned grism PSF kernel stamp size (fine pixels), constant across z.
+
+    The roman_wfi grism PSF is monochromatic at the observed Halpha
+    wavelength, so its GalSim good image size grows with z. Rendering every
+    fit's kernel at the good size of the ensemble's LARGEST observed
+    wavelength keeps the PSF array shape (and the padded FFT shape)
+    constant across the ensemble. Smaller-z kernels are simply drawn on the
+    larger stamp and stay unit-normalized. Gaussian grism PSFs are
+    z-independent, so no pinning applies (returns None).
+    """
+    if config.grism_psf.psf_type == 'gaussian':
+        return None
+    z_draw = spec.draw.get('z')
+    if z_draw is None:
+        raise ValueError(
+            "a roman_wfi grism psf requires z in bank.draw so the kernel "
+            "size can be pinned at the ensemble's largest observed "
+            "wavelength"
+        )
+    if z_draw.dist != 'uniform':
+        raise NotImplementedError(
+            f"grism kernel-size pinning knows the z range for uniform "
+            f"draws only, got dist '{z_draw.dist}'"
+        )
+    z_max = z_draw.params['high']
+    psf_max = _build_grism_psf(config.grism_psf, z_max)
+    fine_ps = config.pixel_scale_arcsec / config.oversample
+    size = int(psf_max.getGoodImageSize(fine_ps))
+    if size % 2 == 0:
+        size += 1
+    return size
 
 
 def _channel_seeds(noise_seed: int, n_channels: int) -> np.ndarray:
@@ -147,7 +281,17 @@ def _grism_pars_for_roll(
 
 
 def _make_roll_obs(
-    source, truth, psf, config, z, roll_deg, single_roll, line_snr, seed, oversample
+    source,
+    truth,
+    psf,
+    config,
+    z,
+    roll_deg,
+    single_roll,
+    line_snr,
+    seed,
+    oversample,
+    psf_kernel_size,
 ):
     grism_pars = _grism_pars_for_roll(config, z, roll_deg, single_roll)
     # render truth at the SAME oversample as the fit obs below (mirrors
@@ -159,6 +303,7 @@ def _make_roll_obs(
         z=z,
         psf=psf,
         render_config=RenderConfig(oversample=oversample),
+        psf_kernel_size=psf_kernel_size,
     )
     data_true = np.asarray(source.render_grism(truth, obs_clean))
     # line-only render (continuum amplitudes zeroed) sets the noise level so the
@@ -177,6 +322,7 @@ def _make_roll_obs(
         render_config=RenderConfig(oversample=oversample),
         data=jnp.asarray(data_noisy),
         variance=var,
+        psf_kernel_size=psf_kernel_size,
     )
 
 
@@ -237,7 +383,7 @@ def build_fit_inputs(
     )
     image_obs = {}
     for i, band in enumerate(config.bands):
-        psf = _build_gaussian_psf(config.band_psf_fwhm[band])
+        psf = _build_band_psf(config.band_psf[band], band)
         image_obs[band] = _make_band_obs(
             source,
             truth,
@@ -249,7 +395,8 @@ def build_fit_inputs(
             config.oversample,
         )
 
-    grism_psf = _build_gaussian_psf(config.grism_psf_fwhm)
+    grism_psf = _build_grism_psf(config.grism_psf, z)
+    grism_kernel_size = _grism_psf_kernel_size(config, spec)
     single_roll = len(config.grism_rolls_deg) == 1
     grism_obs = {}
     for j, roll in enumerate(config.grism_rolls_deg):
@@ -264,6 +411,7 @@ def build_fit_inputs(
             line_snr,
             seeds[len(config.bands) + j],
             config.oversample,
+            grism_kernel_size,
         )
 
     return FitInputs(

--- a/kl_pipe/ensemble/mocks.py
+++ b/kl_pipe/ensemble/mocks.py
@@ -22,8 +22,10 @@ wavelength, grism at the observed Halpha wavelength). Roman grism kernels
 are rendered at a stamp size pinned to the ensemble's largest observed
 wavelength so the PSF array shape is constant across z. On hosts without
 galsim (e.g. Vista NGC containers), the vista_kit GaussianPSFShim mechanism
-applies; this module raises a clear ImportError rather than silently
-substituting.
+applies to GAUSSIAN configs only; roman_wfi needs the real galsim (the
+pupil-plane and aberration data ship inside the galsim package itself, so
+any working install suffices). This module raises a clear ImportError
+rather than silently substituting.
 """
 
 from __future__ import annotations
@@ -82,12 +84,18 @@ def _build_gaussian_psf(fwhm_arcsec: float):
 # a long-lived worker claims many fits at distinct redshifts, so an unbounded
 # cache would accumulate one GSObject per fit; within-fit reuse only needs a
 # handful of entries.
-_ROMAN_PSF_CACHE: Dict[Tuple[int, int, float, Optional[str]], object] = {}
+_ROMAN_PSF_CACHE: Dict[
+    Tuple[int, int, float, Optional[str], Optional[float]], object
+] = {}
 _ROMAN_PSF_CACHE_MAX = 16
 
 
 def _get_roman_wfi_psf(
-    sca: int, pupil_bin: int, wavelength_nm: float, bandpass: Optional[str]
+    sca: int,
+    pupil_bin: int,
+    wavelength_nm: float,
+    bandpass: Optional[str],
+    folding_threshold: Optional[float] = None,
 ):
     """Monochromatic Roman WFI PSF via galsim.roman.getPSF, cached.
 
@@ -104,36 +112,75 @@ def _get_roman_wfi_psf(
     wavelength_nm : float
         Wavelength in nm (galsim.roman.getPSF takes nm).
     bandpass : str or None
-        Roman bandpass name selecting the pupil-plane configuration
+        galsim.roman bandpass key selecting the pupil-plane configuration
         (F184 is the only long-wavelength band); None uses the
         short-wavelength pupil image.
+    folding_threshold : float, optional
+        GSParams folding_threshold applied to the returned PSF; controls
+        the rendered kernel stamp size (and hence the padded convolution
+        FFT). None keeps GalSim's default (5e-3).
     """
     _import_galsim()
+    import galsim
     from galsim import roman
 
-    key = (int(sca), int(pupil_bin), round(float(wavelength_nm), 1), bandpass)
+    key = (
+        int(sca),
+        int(pupil_bin),
+        round(float(wavelength_nm), 1),
+        bandpass,
+        folding_threshold,
+    )
     if key not in _ROMAN_PSF_CACHE:
         while len(_ROMAN_PSF_CACHE) >= _ROMAN_PSF_CACHE_MAX:
             _ROMAN_PSF_CACHE.pop(next(iter(_ROMAN_PSF_CACHE)))
-        _ROMAN_PSF_CACHE[key] = roman.getPSF(
+        psf = roman.getPSF(
             SCA=key[0], bandpass=bandpass, wavelength=key[2], pupil_bin=key[1]
         )
+        if folding_threshold is not None:
+            psf = psf.withGSParams(galsim.GSParams(folding_threshold=folding_threshold))
+        _ROMAN_PSF_CACHE[key] = psf
     return _ROMAN_PSF_CACHE[key]
+
+
+# official Roman WFI filter names -> galsim.roman bandpass keys. galsim
+# kept the legacy WFIRST names (H158, Z087, ...); the official filter set is
+# F062-F213 (roman-docs.stsci.edu), so configs may use either.
+_OFFICIAL_TO_GALSIM_BAND = {
+    'F062': 'R062',
+    'F087': 'Z087',
+    'F106': 'Y106',
+    'F129': 'J129',
+    'F146': 'W146',
+    'F158': 'H158',
+    'F184': 'F184',
+    'F213': 'K213',
+}
+
+
+def _galsim_roman_band(band: str) -> str:
+    """Resolve an official Roman WFI filter name or a galsim legacy key to
+    the galsim.roman bandpass key."""
+    if band in _OFFICIAL_TO_GALSIM_BAND:
+        return _OFFICIAL_TO_GALSIM_BAND[band]
+    if band in _OFFICIAL_TO_GALSIM_BAND.values():
+        return band
+    raise ValueError(
+        f"band '{band}' is not a Roman WFI filter; official names: "
+        f"{sorted(_OFFICIAL_TO_GALSIM_BAND)} (galsim legacy keys "
+        f"{sorted(_OFFICIAL_TO_GALSIM_BAND.values())} also accepted)"
+    )
 
 
 @lru_cache(maxsize=None)
 def _band_effective_wavelength_nm(band: str) -> float:
-    """Effective wavelength (nm) of a Roman WFI bandpass."""
+    """Effective wavelength (nm) of a Roman WFI bandpass (official or
+    galsim legacy name)."""
     _import_galsim()
     from galsim import roman
 
-    bandpasses = roman.getBandpasses()
-    if band not in bandpasses:
-        raise ValueError(
-            f"band '{band}' is not a Roman WFI bandpass; a roman_wfi "
-            f"broadband psf requires one of {sorted(bandpasses)}"
-        )
-    return float(bandpasses[band].effective_wavelength)
+    key = _galsim_roman_band(band)
+    return float(roman.getBandpasses()[key].effective_wavelength)
 
 
 def _build_band_psf(psf_spec: 'PSFSpec', band: str):
@@ -147,7 +194,8 @@ def _build_band_psf(psf_spec: 'PSFSpec', band: str):
             psf_spec.sca,
             psf_spec.pupil_bin,
             _band_effective_wavelength_nm(band),
-            bandpass=band,
+            bandpass=_galsim_roman_band(band),
+            folding_threshold=psf_spec.folding_threshold,
         )
     raise NotImplementedError(f"psf type '{psf_spec.psf_type}' has no mock PSF builder")
 
@@ -165,6 +213,7 @@ def _build_grism_psf(psf_spec: 'PSFSpec', z: float):
             psf_spec.pupil_bin,
             LINE_LAMBDAS['Halpha'] * (1.0 + z),
             bandpass=None,
+            folding_threshold=psf_spec.folding_threshold,
         )
     raise NotImplementedError(f"psf type '{psf_spec.psf_type}' has no mock PSF builder")
 

--- a/kl_pipe/ensemble/mocks.py
+++ b/kl_pipe/ensemble/mocks.py
@@ -186,18 +186,30 @@ def _band_effective_wavelength_nm(band: str) -> float:
     return float(roman.getBandpasses()[key].effective_wavelength)
 
 
-def _spec_folding_threshold(psf_spec: 'PSFSpec', mock: bool) -> Optional[float]:
-    """Folding threshold for the requested role: fit kernels use
-    ``folding_threshold``, truth-render kernels use ``mock_folding_threshold``
-    (both None = galsim default; mock validated at least as accurate)."""
-    return psf_spec.mock_folding_threshold if mock else psf_spec.folding_threshold
+def _spec_folding_threshold(
+    psf_spec: 'PSFSpec', mock: bool, z: Optional[float] = None
+) -> Optional[float]:
+    """Folding threshold for the requested role: fit kernels resolve
+    ``folding_threshold``/``folding_threshold_tiers`` at the scene redshift
+    ``z``, truth-render kernels use ``mock_folding_threshold`` (all None =
+    galsim default; mock validated at least as accurate at every z).
+
+    ``z`` is consulted only for a tiered fit schedule; a scalar/None fit
+    threshold ignores it, and a tiered schedule with ``z is None`` raises
+    loudly (rather than silently picking a tier)."""
+    if mock:
+        return psf_spec.mock_folding_threshold
+    return psf_spec.resolve_fit_folding_threshold(z)
 
 
-def _build_band_psf(psf_spec: 'PSFSpec', band: str, mock: bool = False):
+def _build_band_psf(
+    psf_spec: 'PSFSpec', band: str, z: Optional[float] = None, mock: bool = False
+):
     """Broadband PSF for one band from its PSFSpec.
 
     mock=True selects the truth-render kernel fidelity
-    (``mock_folding_threshold``); mock=False the fit-kernel fidelity.
+    (``mock_folding_threshold``); mock=False the fit-kernel fidelity, whose
+    folding_threshold may depend on the scene redshift ``z`` (tier schedule).
     """
     if psf_spec.psf_type == 'gaussian':
         return _build_gaussian_psf(psf_spec.fwhm_arcsec)
@@ -209,7 +221,7 @@ def _build_band_psf(psf_spec: 'PSFSpec', band: str, mock: bool = False):
             psf_spec.pupil_bin,
             _band_effective_wavelength_nm(band),
             bandpass=_galsim_roman_band(band),
-            folding_threshold=_spec_folding_threshold(psf_spec, mock),
+            folding_threshold=_spec_folding_threshold(psf_spec, mock, z),
         )
     raise NotImplementedError(f"psf type '{psf_spec.psf_type}' has no mock PSF builder")
 
@@ -218,7 +230,8 @@ def _build_grism_psf(psf_spec: 'PSFSpec', z: float, mock: bool = False):
     """Grism PSF from its PSFSpec, at the observed Halpha wavelength.
 
     mock=True selects the truth-render kernel fidelity
-    (``mock_folding_threshold``); mock=False the fit-kernel fidelity.
+    (``mock_folding_threshold``); mock=False the fit-kernel fidelity, whose
+    folding_threshold may depend on the scene redshift ``z`` (tier schedule).
     """
     if psf_spec.psf_type == 'gaussian':
         return _build_gaussian_psf(psf_spec.fwhm_arcsec)
@@ -231,7 +244,7 @@ def _build_grism_psf(psf_spec: 'PSFSpec', z: float, mock: bool = False):
             psf_spec.pupil_bin,
             LINE_LAMBDAS['Halpha'] * (1.0 + z),
             bandpass=None,
-            folding_threshold=_spec_folding_threshold(psf_spec, mock),
+            folding_threshold=_spec_folding_threshold(psf_spec, mock, z),
         )
     raise NotImplementedError(f"psf type '{psf_spec.psf_type}' has no mock PSF builder")
 
@@ -469,8 +482,8 @@ def build_fit_inputs(
         image_obs[band] = _make_band_obs(
             source,
             truth,
-            _build_band_psf(band_spec, band, mock=True),
-            _build_band_psf(band_spec, band),
+            _build_band_psf(band_spec, band, z, mock=True),
+            _build_band_psf(band_spec, band, z),
             image_pars,
             band,
             broadband_snr,

--- a/kl_pipe/ensemble/mocks.py
+++ b/kl_pipe/ensemble/mocks.py
@@ -20,7 +20,10 @@ PSFs are built per channel from the observing config's ``PSFSpec``:
 (monochromatic ``galsim.roman.getPSF``; broadband at the band's effective
 wavelength, grism at the observed Halpha wavelength). Roman grism kernels
 are rendered at a stamp size pinned to the ensemble's largest observed
-wavelength so the PSF array shape is constant across z. On hosts without
+wavelength so the PSF array shape is constant across z. When the PSFSpec
+loosens the fit-kernel ``folding_threshold``, mock/truth data is still
+rendered through the tighter ``mock_folding_threshold`` kernels (default:
+galsim's 5e-3) -- the mock is always at least as accurate as the fit model. On hosts without
 galsim (e.g. Vista NGC containers), the vista_kit GaussianPSFShim mechanism
 applies to GAUSSIAN configs only; roman_wfi needs the real galsim (the
 pupil-plane and aberration data ship inside the galsim package itself, so
@@ -183,8 +186,19 @@ def _band_effective_wavelength_nm(band: str) -> float:
     return float(roman.getBandpasses()[key].effective_wavelength)
 
 
-def _build_band_psf(psf_spec: 'PSFSpec', band: str):
-    """Broadband PSF for one band from its PSFSpec."""
+def _spec_folding_threshold(psf_spec: 'PSFSpec', mock: bool) -> Optional[float]:
+    """Folding threshold for the requested role: fit kernels use
+    ``folding_threshold``, truth-render kernels use ``mock_folding_threshold``
+    (both None = galsim default; mock validated at least as accurate)."""
+    return psf_spec.mock_folding_threshold if mock else psf_spec.folding_threshold
+
+
+def _build_band_psf(psf_spec: 'PSFSpec', band: str, mock: bool = False):
+    """Broadband PSF for one band from its PSFSpec.
+
+    mock=True selects the truth-render kernel fidelity
+    (``mock_folding_threshold``); mock=False the fit-kernel fidelity.
+    """
     if psf_spec.psf_type == 'gaussian':
         return _build_gaussian_psf(psf_spec.fwhm_arcsec)
     if psf_spec.psf_type == 'roman_wfi':
@@ -195,13 +209,17 @@ def _build_band_psf(psf_spec: 'PSFSpec', band: str):
             psf_spec.pupil_bin,
             _band_effective_wavelength_nm(band),
             bandpass=_galsim_roman_band(band),
-            folding_threshold=psf_spec.folding_threshold,
+            folding_threshold=_spec_folding_threshold(psf_spec, mock),
         )
     raise NotImplementedError(f"psf type '{psf_spec.psf_type}' has no mock PSF builder")
 
 
-def _build_grism_psf(psf_spec: 'PSFSpec', z: float):
-    """Grism PSF from its PSFSpec, at the observed Halpha wavelength."""
+def _build_grism_psf(psf_spec: 'PSFSpec', z: float, mock: bool = False):
+    """Grism PSF from its PSFSpec, at the observed Halpha wavelength.
+
+    mock=True selects the truth-render kernel fidelity
+    (``mock_folding_threshold``); mock=False the fit-kernel fidelity.
+    """
     if psf_spec.psf_type == 'gaussian':
         return _build_gaussian_psf(psf_spec.fwhm_arcsec)
     if psf_spec.psf_type == 'roman_wfi':
@@ -213,15 +231,16 @@ def _build_grism_psf(psf_spec: 'PSFSpec', z: float):
             psf_spec.pupil_bin,
             LINE_LAMBDAS['Halpha'] * (1.0 + z),
             bandpass=None,
-            folding_threshold=psf_spec.folding_threshold,
+            folding_threshold=_spec_folding_threshold(psf_spec, mock),
         )
     raise NotImplementedError(f"psf type '{psf_spec.psf_type}' has no mock PSF builder")
 
 
 def _grism_psf_kernel_size(
-    config: 'ObservingConfig', spec: 'EnsembleSpec'
+    config: 'ObservingConfig', spec: 'EnsembleSpec', mock: bool = False
 ) -> Optional[int]:
     """Pinned grism PSF kernel stamp size (fine pixels), constant across z.
+    mock=True sizes the truth-render kernel (mock_folding_threshold fidelity).
 
     The roman_wfi grism PSF is monochromatic at the observed Halpha
     wavelength, so its GalSim good image size grows with z. Rendering every
@@ -246,7 +265,7 @@ def _grism_psf_kernel_size(
             f"draws only, got dist '{z_draw.dist}'"
         )
     z_max = z_draw.params['high']
-    psf_max = _build_grism_psf(config.grism_psf, z_max)
+    psf_max = _build_grism_psf(config.grism_psf, z_max, mock=mock)
     fine_ps = config.pixel_scale_arcsec / config.oversample
     size = int(psf_max.getGoodImageSize(fine_ps))
     if size % 2 == 0:
@@ -287,11 +306,15 @@ def _wcs_with_pc(shape, pixel_scale: float, rotation_radians: float):
     return wcs
 
 
-def _make_band_obs(source, truth, psf, image_pars, band, snr, seed, oversample):
+def _make_band_obs(
+    source, truth, psf_mock, psf_fit, image_pars, band, snr, seed, oversample
+):
     int_model = source.broadband_models[band]
+    # truth data through the mock-fidelity kernel; the fit obs carries the
+    # fit-fidelity kernel (identical objects unless the PSFSpec splits them)
     obs_clean = build_image_obs(
         image_pars,
-        psf=psf,
+        psf=psf_mock,
         render_config=RenderConfig(oversample=oversample),
         int_model=int_model,
         broadband_key=band,
@@ -300,7 +323,7 @@ def _make_band_obs(source, truth, psf, image_pars, band, snr, seed, oversample):
     data_noisy, var = _noisy(data_true, snr, seed)
     return build_image_obs(
         image_pars,
-        psf=psf,
+        psf=psf_fit,
         render_config=RenderConfig(oversample=oversample),
         data=jnp.asarray(data_noisy),
         variance=var,
@@ -338,7 +361,8 @@ def _grism_pars_for_roll(
 def _make_roll_obs(
     source,
     truth,
-    psf,
+    psf_mock,
+    psf_fit,
     config,
     z,
     roll_deg,
@@ -346,19 +370,22 @@ def _make_roll_obs(
     line_snr,
     seed,
     oversample,
-    psf_kernel_size,
+    kernel_size_mock,
+    kernel_size_fit,
 ):
     grism_pars = _grism_pars_for_roll(config, z, roll_deg, single_roll)
     # render truth at the SAME oversample as the fit obs below (mirrors
     # _make_band_obs); otherwise the grism truth datavector is generated at the
     # RenderConfig default oversample=1 while the fit runs at config.oversample,
-    # silently breaking grism fit==truth self-consistency
+    # silently breaking grism fit==truth self-consistency. The truth data goes
+    # through the mock-fidelity kernel; the fit obs carries the fit-fidelity
+    # kernel (identical unless the PSFSpec splits them).
     obs_clean = build_grism_obs(
         grism_pars,
         z=z,
-        psf=psf,
+        psf=psf_mock,
         render_config=RenderConfig(oversample=oversample),
-        psf_kernel_size=psf_kernel_size,
+        psf_kernel_size=kernel_size_mock,
     )
     data_true = np.asarray(source.render_grism(truth, obs_clean))
     # line-only render (continuum amplitudes zeroed) sets the noise level so the
@@ -373,11 +400,11 @@ def _make_roll_obs(
     return build_grism_obs(
         grism_pars,
         z=z,
-        psf=psf,
+        psf=psf_fit,
         render_config=RenderConfig(oversample=oversample),
         data=jnp.asarray(data_noisy),
         variance=var,
-        psf_kernel_size=psf_kernel_size,
+        psf_kernel_size=kernel_size_fit,
     )
 
 
@@ -438,11 +465,12 @@ def build_fit_inputs(
     )
     image_obs = {}
     for i, band in enumerate(config.bands):
-        psf = _build_band_psf(config.band_psf[band], band)
+        band_spec = config.band_psf[band]
         image_obs[band] = _make_band_obs(
             source,
             truth,
-            psf,
+            _build_band_psf(band_spec, band, mock=True),
+            _build_band_psf(band_spec, band),
             image_pars,
             band,
             broadband_snr,
@@ -450,15 +478,18 @@ def build_fit_inputs(
             config.oversample,
         )
 
-    grism_psf = _build_grism_psf(config.grism_psf, z)
-    grism_kernel_size = _grism_psf_kernel_size(config, spec)
+    grism_psf_mock = _build_grism_psf(config.grism_psf, z, mock=True)
+    grism_psf_fit = _build_grism_psf(config.grism_psf, z)
+    kernel_size_mock = _grism_psf_kernel_size(config, spec, mock=True)
+    kernel_size_fit = _grism_psf_kernel_size(config, spec)
     single_roll = len(config.grism_rolls_deg) == 1
     grism_obs = {}
     for j, roll in enumerate(config.grism_rolls_deg):
         grism_obs[f'roll{j}'] = _make_roll_obs(
             source,
             truth,
-            grism_psf,
+            grism_psf_mock,
+            grism_psf_fit,
             config,
             z,
             roll,
@@ -466,7 +497,8 @@ def build_fit_inputs(
             line_snr,
             seeds[len(config.bands) + j],
             config.oversample,
-            grism_kernel_size,
+            kernel_size_mock,
+            kernel_size_fit,
         )
 
     return FitInputs(

--- a/kl_pipe/ensemble/scene.py
+++ b/kl_pipe/ensemble/scene.py
@@ -34,15 +34,20 @@ if TYPE_CHECKING:
     from kl_pipe.ensemble.spec import EnsembleSpec, ObservingConfig
     from kl_pipe.source import SourceModel
 
-# per-band scene defaults (flagship values)
+# per-band scene defaults (flagship values; H158/F184 are real Roman WFI
+# bandpasses mirroring the flagship F158/F087 values, F184 slightly fainter)
 _BAND_TRUTH = {
     'F087': {'flux': 100.0, 'rscale': 0.3},
     'F158': {'flux': 120.0, 'rscale': 0.35},
+    'H158': {'flux': 120.0, 'rscale': 0.35},
+    'F184': {'flux': 100.0, 'rscale': 0.35},
 }
 # per-band flux prior (mu, sigma, low, high)
 _BAND_FLUX_PRIOR = {
     'F087': (100.0, 20.0, 30.0, 250.0),
     'F158': (120.0, 25.0, 30.0, 300.0),
+    'H158': (120.0, 25.0, 30.0, 300.0),
+    'F184': (100.0, 20.0, 30.0, 250.0),
 }
 
 # shared scene defaults (flagship values)

--- a/kl_pipe/ensemble/scene.py
+++ b/kl_pipe/ensemble/scene.py
@@ -34,19 +34,17 @@ if TYPE_CHECKING:
     from kl_pipe.ensemble.spec import EnsembleSpec, ObservingConfig
     from kl_pipe.source import SourceModel
 
-# per-band scene defaults (flagship values; H158/F184 are real Roman WFI
-# bandpasses mirroring the flagship F158/F087 values, F184 slightly fainter)
+# per-band scene defaults (flagship values; F184 mirrors F087, slightly
+# fainter than F158)
 _BAND_TRUTH = {
     'F087': {'flux': 100.0, 'rscale': 0.3},
     'F158': {'flux': 120.0, 'rscale': 0.35},
-    'H158': {'flux': 120.0, 'rscale': 0.35},
     'F184': {'flux': 100.0, 'rscale': 0.35},
 }
 # per-band flux prior (mu, sigma, low, high)
 _BAND_FLUX_PRIOR = {
     'F087': (100.0, 20.0, 30.0, 250.0),
     'F158': (120.0, 25.0, 30.0, 300.0),
-    'H158': (120.0, 25.0, 30.0, 300.0),
     'F184': (100.0, 20.0, 30.0, 250.0),
 }
 

--- a/kl_pipe/ensemble/spec.py
+++ b/kl_pipe/ensemble/spec.py
@@ -47,6 +47,7 @@ def _reject_unknown(d: dict, allowed: Tuple[str, ...], context: str) -> None:
 _PSF_TYPES = ('gaussian', 'roman_wfi')
 _ROMAN_WFI_DEFAULT_SCA = 10
 _ROMAN_WFI_DEFAULT_PUPIL_BIN = 4
+_GALSIM_DEFAULT_FOLDING_THRESHOLD = 5e-3
 
 
 @dataclass(frozen=True)
@@ -55,19 +56,29 @@ class PSFSpec:
 
     ``gaussian`` carries ``fwhm_arcsec``; ``roman_wfi`` (realistic WFI PSF
     via ``galsim.roman.getPSF``, monochromatic) carries ``sca`` and
-    ``pupil_bin``, plus an optional ``folding_threshold`` (GalSim GSParams;
-    None keeps GalSim's default 5e-3). A looser threshold shrinks the
-    rendered kernel stamp -- and with it the padded convolution FFT --
-    at the cost of truncating more far-wing flux; see the accuracy/speed
-    table in the PR notes before loosening for production. Cross-type
-    fields must be None (raises otherwise).
+    ``pupil_bin``, plus two optional GSParams folding thresholds (None keeps
+    GalSim's default 5e-3). A looser threshold shrinks the rendered kernel
+    stamp -- and with it the padded convolution FFT -- at the cost of
+    truncating more far-wing flux.
+
+    ``folding_threshold`` applies to the FIT-model kernels (the per-eval
+    convolution cost); ``mock_folding_threshold`` applies to the TRUTH
+    (mock-data) render kernels, paid once per fit. Leaving
+    ``mock_folding_threshold`` at None while loosening ``folding_threshold``
+    gives the realistic asymmetry: mock data is rendered at higher kernel
+    fidelity than the inference model. The mock kernels must be at least as
+    accurate as the fit kernels (raises otherwise). Parameter-level bias
+    from the split was gated at folding_threshold=0.01 (all MAP shifts
+    <= 0.07 sigma vs a matched-kernel control at line SNR 100); 0.02 fails
+    that gate. Cross-type fields must be None (raises otherwise).
     """
 
     psf_type: str
     fwhm_arcsec: Optional[float] = None  # gaussian only, arcsec
     sca: Optional[int] = None  # roman_wfi only, 1-18
     pupil_bin: Optional[int] = None  # roman_wfi only
-    folding_threshold: Optional[float] = None  # roman_wfi only, None = galsim default
+    folding_threshold: Optional[float] = None  # roman_wfi only, fit kernels
+    mock_folding_threshold: Optional[float] = None  # roman_wfi only, truth kernels
 
     def __post_init__(self):
         if self.psf_type == 'gaussian':
@@ -78,8 +89,14 @@ class PSFSpec:
                 )
             if self.sca is not None or self.pupil_bin is not None:
                 raise ValueError("sca/pupil_bin are roman_wfi-only psf fields")
-            if self.folding_threshold is not None:
-                raise ValueError("folding_threshold is a roman_wfi-only psf field")
+            if (
+                self.folding_threshold is not None
+                or self.mock_folding_threshold is not None
+            ):
+                raise ValueError(
+                    "folding_threshold/mock_folding_threshold are "
+                    "roman_wfi-only psf fields"
+                )
         elif self.psf_type == 'roman_wfi':
             if self.fwhm_arcsec is not None:
                 raise ValueError("fwhm_arcsec is a gaussian-only psf field")
@@ -92,13 +109,32 @@ class PSFSpec:
                     f"roman_wfi pupil_bin must be a positive int, got "
                     f"{self.pupil_bin!r}"
                 )
-            if self.folding_threshold is not None:
-                ft = self.folding_threshold
-                if not isinstance(ft, float) or not (0.0 < ft < 1.0):
+            for name in ('folding_threshold', 'mock_folding_threshold'):
+                ft = getattr(self, name)
+                if ft is not None and (
+                    not isinstance(ft, float) or not (0.0 < ft < 1.0)
+                ):
                     raise ValueError(
-                        f"roman_wfi folding_threshold must be a float in "
-                        f"(0, 1), got {ft!r}"
+                        f"roman_wfi {name} must be a float in (0, 1), got {ft!r}"
                     )
+            # mock kernels must be at least as accurate as fit kernels
+            # (None = galsim default 5e-3)
+            mock_eff = (
+                self.mock_folding_threshold
+                if self.mock_folding_threshold is not None
+                else _GALSIM_DEFAULT_FOLDING_THRESHOLD
+            )
+            fit_eff = (
+                self.folding_threshold
+                if self.folding_threshold is not None
+                else _GALSIM_DEFAULT_FOLDING_THRESHOLD
+            )
+            if mock_eff > fit_eff:
+                raise ValueError(
+                    f"mock_folding_threshold ({mock_eff}) must be <= the fit "
+                    f"folding_threshold ({fit_eff}): truth-render kernels "
+                    f"must be at least as accurate as fit kernels"
+                )
         else:
             raise NotImplementedError(
                 f"psf type {self.psf_type!r} not supported; supported types: "
@@ -118,17 +154,22 @@ def _require_yaml_int(block: dict, key: str, default: int, context: str) -> int:
 
 
 def _parse_roman_wfi_psf(block: dict, context: str) -> PSFSpec:
-    _reject_unknown(block, ('type', 'sca', 'pupil_bin', 'folding_threshold'), context)
-    folding_threshold = block.get('folding_threshold')
-    if folding_threshold is not None:
-        folding_threshold = float(folding_threshold)
+    _reject_unknown(
+        block,
+        ('type', 'sca', 'pupil_bin', 'folding_threshold', 'mock_folding_threshold'),
+        context,
+    )
+    thresholds = {}
+    for key in ('folding_threshold', 'mock_folding_threshold'):
+        value = block.get(key)
+        thresholds[key] = float(value) if value is not None else None
     return PSFSpec(
         psf_type='roman_wfi',
         sca=_require_yaml_int(block, 'sca', _ROMAN_WFI_DEFAULT_SCA, context),
         pupil_bin=_require_yaml_int(
             block, 'pupil_bin', _ROMAN_WFI_DEFAULT_PUPIL_BIN, context
         ),
-        folding_threshold=folding_threshold,
+        **thresholds,
     )
 
 

--- a/kl_pipe/ensemble/spec.py
+++ b/kl_pipe/ensemble/spec.py
@@ -91,12 +91,25 @@ class PSFSpec:
             )
 
 
+def _require_yaml_int(block: dict, key: str, default: int, context: str) -> int:
+    """Fetch an integer key, rejecting floats/strings instead of coercing."""
+    val = block.get(key, default)
+    if isinstance(val, bool) or not isinstance(val, int):
+        raise ValueError(
+            f"{context}: '{key}' must be an integer, got {val!r} "
+            f"({type(val).__name__})"
+        )
+    return val
+
+
 def _parse_roman_wfi_psf(block: dict, context: str) -> PSFSpec:
     _reject_unknown(block, ('type', 'sca', 'pupil_bin'), context)
     return PSFSpec(
         psf_type='roman_wfi',
-        sca=int(block.get('sca', _ROMAN_WFI_DEFAULT_SCA)),
-        pupil_bin=int(block.get('pupil_bin', _ROMAN_WFI_DEFAULT_PUPIL_BIN)),
+        sca=_require_yaml_int(block, 'sca', _ROMAN_WFI_DEFAULT_SCA, context),
+        pupil_bin=_require_yaml_int(
+            block, 'pupil_bin', _ROMAN_WFI_DEFAULT_PUPIL_BIN, context
+        ),
     )
 
 

--- a/kl_pipe/ensemble/spec.py
+++ b/kl_pipe/ensemble/spec.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import hashlib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 import yaml
 
@@ -44,6 +44,107 @@ def _reject_unknown(d: dict, allowed: Tuple[str, ...], context: str) -> None:
 # Observing-config registry
 # =============================================================================
 
+_PSF_TYPES = ('gaussian', 'roman_wfi')
+_ROMAN_WFI_DEFAULT_SCA = 10
+_ROMAN_WFI_DEFAULT_PUPIL_BIN = 4
+
+
+@dataclass(frozen=True)
+class PSFSpec:
+    """One channel's PSF specification (a broadband band or the grism).
+
+    ``gaussian`` carries ``fwhm_arcsec``; ``roman_wfi`` (realistic WFI PSF
+    via ``galsim.roman.getPSF``, monochromatic) carries ``sca`` and
+    ``pupil_bin``. Cross-type fields must be None (raises otherwise).
+    """
+
+    psf_type: str
+    fwhm_arcsec: Optional[float] = None  # gaussian only, arcsec
+    sca: Optional[int] = None  # roman_wfi only, 1-18
+    pupil_bin: Optional[int] = None  # roman_wfi only
+
+    def __post_init__(self):
+        if self.psf_type == 'gaussian':
+            if self.fwhm_arcsec is None or self.fwhm_arcsec <= 0:
+                raise ValueError(
+                    f"gaussian psf needs a positive fwhm_arcsec, got "
+                    f"{self.fwhm_arcsec!r}"
+                )
+            if self.sca is not None or self.pupil_bin is not None:
+                raise ValueError("sca/pupil_bin are roman_wfi-only psf fields")
+        elif self.psf_type == 'roman_wfi':
+            if self.fwhm_arcsec is not None:
+                raise ValueError("fwhm_arcsec is a gaussian-only psf field")
+            if not isinstance(self.sca, int) or not (1 <= self.sca <= 18):
+                raise ValueError(
+                    f"roman_wfi sca must be an int in [1, 18], got {self.sca!r}"
+                )
+            if not isinstance(self.pupil_bin, int) or self.pupil_bin < 1:
+                raise ValueError(
+                    f"roman_wfi pupil_bin must be a positive int, got "
+                    f"{self.pupil_bin!r}"
+                )
+        else:
+            raise NotImplementedError(
+                f"psf type {self.psf_type!r} not supported; supported types: "
+                f"{list(_PSF_TYPES)}"
+            )
+
+
+def _parse_roman_wfi_psf(block: dict, context: str) -> PSFSpec:
+    _reject_unknown(block, ('type', 'sca', 'pupil_bin'), context)
+    return PSFSpec(
+        psf_type='roman_wfi',
+        sca=int(block.get('sca', _ROMAN_WFI_DEFAULT_SCA)),
+        pupil_bin=int(block.get('pupil_bin', _ROMAN_WFI_DEFAULT_PUPIL_BIN)),
+    )
+
+
+def _parse_broadband_psf(
+    block: dict, bands: Tuple[str, ...], context: str
+) -> Dict[str, PSFSpec]:
+    psf_type = block.get('type')
+    if psf_type == 'gaussian':
+        _reject_unknown(block, ('type', 'fwhm_arcsec'), context)
+        _require_keys(block, ('type', 'fwhm_arcsec'), context)
+        fwhm = block['fwhm_arcsec']
+        if not isinstance(fwhm, dict):
+            raise ValueError(
+                f"{context}: broadband gaussian fwhm_arcsec must be a "
+                f"band -> arcsec mapping, got {fwhm!r}"
+            )
+        return {
+            band: PSFSpec(psf_type='gaussian', fwhm_arcsec=float(value))
+            for band, value in fwhm.items()
+        }
+    if psf_type == 'roman_wfi':
+        spec = _parse_roman_wfi_psf(block, context)
+        return {band: spec for band in bands}
+    raise NotImplementedError(
+        f"{context}: psf type {psf_type!r} not supported; supported types: "
+        f"{list(_PSF_TYPES)}"
+    )
+
+
+def _parse_grism_psf(block: dict, context: str) -> PSFSpec:
+    psf_type = block.get('type')
+    if psf_type == 'gaussian':
+        _reject_unknown(block, ('type', 'fwhm_arcsec'), context)
+        _require_keys(block, ('type', 'fwhm_arcsec'), context)
+        fwhm = block['fwhm_arcsec']
+        if isinstance(fwhm, dict):
+            raise ValueError(
+                f"{context}: grism gaussian fwhm_arcsec must be a scalar, "
+                f"got {fwhm!r}"
+            )
+        return PSFSpec(psf_type='gaussian', fwhm_arcsec=float(fwhm))
+    if psf_type == 'roman_wfi':
+        return _parse_roman_wfi_psf(block, context)
+    raise NotImplementedError(
+        f"{context}: psf type {psf_type!r} not supported; supported types: "
+        f"{list(_PSF_TYPES)}"
+    )
+
 
 @dataclass(frozen=True)
 class ObservingConfig:
@@ -51,10 +152,10 @@ class ObservingConfig:
 
     id: str
     bands: Tuple[str, ...]
-    band_psf_fwhm: Dict[str, float]  # arcsec, per band
+    band_psf: Dict[str, PSFSpec]  # per band
     grism_rolls_deg: Tuple[float, ...]
     grism_dispersion_nm_per_pix: float
-    grism_psf_fwhm: float  # arcsec (gaussian; complex WFI PSF is a future gap)
+    grism_psf: PSFSpec
     lines: Tuple[str, ...]
     pixel_scale_arcsec: float
     stamp_broadband_pix: int
@@ -66,8 +167,12 @@ class ObservingConfig:
         if not self.bands:
             raise ValueError("observing config needs at least one band")
         for band in self.bands:
-            if band not in self.band_psf_fwhm:
-                raise ValueError(f"band '{band}' has no psf fwhm in broadband psf spec")
+            if band not in self.band_psf:
+                raise ValueError(f"band '{band}' has no entry in broadband psf spec")
+            if not isinstance(self.band_psf[band], PSFSpec):
+                raise ValueError(f"band '{band}' psf entry must be a PSFSpec")
+        if not isinstance(self.grism_psf, PSFSpec):
+            raise ValueError("grism_psf must be a PSFSpec")
         if not self.grism_rolls_deg:
             raise ValueError("observing config needs at least one grism roll")
         if tuple(self.lines) != ('Halpha',):
@@ -76,7 +181,6 @@ class ObservingConfig:
             )
         for name, value in [
             ('grism_dispersion_nm_per_pix', self.grism_dispersion_nm_per_pix),
-            ('grism_psf_fwhm', self.grism_psf_fwhm),
             ('pixel_scale_arcsec', self.pixel_scale_arcsec),
         ]:
             if value <= 0:
@@ -88,6 +192,27 @@ class ObservingConfig:
         ]:
             if not isinstance(value, int) or value <= 0:
                 raise ValueError(f"{name} ({value}) must be a positive int")
+
+    @property
+    def band_psf_fwhm(self) -> Dict[str, float]:
+        """Per-band gaussian FWHM (arcsec). Raises for non-gaussian PSFs."""
+        for band, psf in self.band_psf.items():
+            if psf.psf_type != 'gaussian':
+                raise ValueError(
+                    f"band_psf_fwhm is defined for gaussian PSFs only; band "
+                    f"'{band}' has psf type '{psf.psf_type}' (use band_psf)"
+                )
+        return {band: psf.fwhm_arcsec for band, psf in self.band_psf.items()}
+
+    @property
+    def grism_psf_fwhm(self) -> float:
+        """Grism gaussian FWHM (arcsec). Raises for non-gaussian PSFs."""
+        if self.grism_psf.psf_type != 'gaussian':
+            raise ValueError(
+                f"grism_psf_fwhm is defined for gaussian PSFs only; grism "
+                f"psf type is '{self.grism_psf.psf_type}' (use grism_psf)"
+            )
+        return self.grism_psf.fwhm_arcsec
 
     @classmethod
     def from_yaml(cls, path: Path) -> 'ObservingConfig':
@@ -116,13 +241,10 @@ class ObservingConfig:
         psf = raw['psf']
         _reject_unknown(psf, ('broadband', 'grism'), f"{path}:psf")
         _require_keys(psf, ('broadband', 'grism'), f"{path}:psf")
-        for key in ('broadband', 'grism'):
-            if psf[key].get('type') != 'gaussian':
-                raise NotImplementedError(
-                    f"{path}:psf.{key}: only type 'gaussian' is supported in v1 "
-                    f"(complex WFI grism PSF is a known gap), got "
-                    f"{psf[key].get('type')!r}"
-                )
+        band_psf = _parse_broadband_psf(
+            psf['broadband'], tuple(raw['bands']), f"{path}:psf.broadband"
+        )
+        grism_psf = _parse_grism_psf(psf['grism'], f"{path}:psf.grism")
 
         stamp = raw['stamp']
         _reject_unknown(stamp, ('broadband_pix', 'grism_pix'), f"{path}:stamp")
@@ -135,12 +257,10 @@ class ObservingConfig:
         return cls(
             id=str(raw['id']),
             bands=tuple(raw['bands']),
-            band_psf_fwhm={
-                k: float(v) for k, v in psf['broadband']['fwhm_arcsec'].items()
-            },
+            band_psf=band_psf,
             grism_rolls_deg=tuple(float(a) for a in grism['rolls_deg']),
             grism_dispersion_nm_per_pix=float(grism['dispersion_nm_per_pix']),
-            grism_psf_fwhm=float(psf['grism']['fwhm_arcsec']),
+            grism_psf=grism_psf,
             lines=tuple(raw['lines']),
             pixel_scale_arcsec=float(raw['pixel_scale_arcsec']),
             stamp_broadband_pix=int(stamp['broadband_pix']),

--- a/kl_pipe/ensemble/spec.py
+++ b/kl_pipe/ensemble/spec.py
@@ -55,13 +55,19 @@ class PSFSpec:
 
     ``gaussian`` carries ``fwhm_arcsec``; ``roman_wfi`` (realistic WFI PSF
     via ``galsim.roman.getPSF``, monochromatic) carries ``sca`` and
-    ``pupil_bin``. Cross-type fields must be None (raises otherwise).
+    ``pupil_bin``, plus an optional ``folding_threshold`` (GalSim GSParams;
+    None keeps GalSim's default 5e-3). A looser threshold shrinks the
+    rendered kernel stamp -- and with it the padded convolution FFT --
+    at the cost of truncating more far-wing flux; see the accuracy/speed
+    table in the PR notes before loosening for production. Cross-type
+    fields must be None (raises otherwise).
     """
 
     psf_type: str
     fwhm_arcsec: Optional[float] = None  # gaussian only, arcsec
     sca: Optional[int] = None  # roman_wfi only, 1-18
     pupil_bin: Optional[int] = None  # roman_wfi only
+    folding_threshold: Optional[float] = None  # roman_wfi only, None = galsim default
 
     def __post_init__(self):
         if self.psf_type == 'gaussian':
@@ -72,6 +78,8 @@ class PSFSpec:
                 )
             if self.sca is not None or self.pupil_bin is not None:
                 raise ValueError("sca/pupil_bin are roman_wfi-only psf fields")
+            if self.folding_threshold is not None:
+                raise ValueError("folding_threshold is a roman_wfi-only psf field")
         elif self.psf_type == 'roman_wfi':
             if self.fwhm_arcsec is not None:
                 raise ValueError("fwhm_arcsec is a gaussian-only psf field")
@@ -84,6 +92,13 @@ class PSFSpec:
                     f"roman_wfi pupil_bin must be a positive int, got "
                     f"{self.pupil_bin!r}"
                 )
+            if self.folding_threshold is not None:
+                ft = self.folding_threshold
+                if not isinstance(ft, float) or not (0.0 < ft < 1.0):
+                    raise ValueError(
+                        f"roman_wfi folding_threshold must be a float in "
+                        f"(0, 1), got {ft!r}"
+                    )
         else:
             raise NotImplementedError(
                 f"psf type {self.psf_type!r} not supported; supported types: "
@@ -103,13 +118,17 @@ def _require_yaml_int(block: dict, key: str, default: int, context: str) -> int:
 
 
 def _parse_roman_wfi_psf(block: dict, context: str) -> PSFSpec:
-    _reject_unknown(block, ('type', 'sca', 'pupil_bin'), context)
+    _reject_unknown(block, ('type', 'sca', 'pupil_bin', 'folding_threshold'), context)
+    folding_threshold = block.get('folding_threshold')
+    if folding_threshold is not None:
+        folding_threshold = float(folding_threshold)
     return PSFSpec(
         psf_type='roman_wfi',
         sca=_require_yaml_int(block, 'sca', _ROMAN_WFI_DEFAULT_SCA, context),
         pupil_bin=_require_yaml_int(
             block, 'pupil_bin', _ROMAN_WFI_DEFAULT_PUPIL_BIN, context
         ),
+        folding_threshold=folding_threshold,
     )
 
 
@@ -205,27 +224,6 @@ class ObservingConfig:
         ]:
             if not isinstance(value, int) or value <= 0:
                 raise ValueError(f"{name} ({value}) must be a positive int")
-
-    @property
-    def band_psf_fwhm(self) -> Dict[str, float]:
-        """Per-band gaussian FWHM (arcsec). Raises for non-gaussian PSFs."""
-        for band, psf in self.band_psf.items():
-            if psf.psf_type != 'gaussian':
-                raise ValueError(
-                    f"band_psf_fwhm is defined for gaussian PSFs only; band "
-                    f"'{band}' has psf type '{psf.psf_type}' (use band_psf)"
-                )
-        return {band: psf.fwhm_arcsec for band, psf in self.band_psf.items()}
-
-    @property
-    def grism_psf_fwhm(self) -> float:
-        """Grism gaussian FWHM (arcsec). Raises for non-gaussian PSFs."""
-        if self.grism_psf.psf_type != 'gaussian':
-            raise ValueError(
-                f"grism_psf_fwhm is defined for gaussian PSFs only; grism "
-                f"psf type is '{self.grism_psf.psf_type}' (use grism_psf)"
-            )
-        return self.grism_psf.fwhm_arcsec
 
     @classmethod
     def from_yaml(cls, path: Path) -> 'ObservingConfig':

--- a/kl_pipe/ensemble/spec.py
+++ b/kl_pipe/ensemble/spec.py
@@ -19,6 +19,7 @@ Unknown YAML keys raise. Every enum-like field is validated at construction.
 from __future__ import annotations
 
 import hashlib
+import math
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional, Tuple
@@ -51,34 +52,102 @@ _GALSIM_DEFAULT_FOLDING_THRESHOLD = 5e-3
 
 
 @dataclass(frozen=True)
+class FoldingThresholdTier:
+    """One redshift tier of the fit-kernel folding_threshold schedule.
+
+    ``z_max`` is the inclusive upper redshift bound this tier covers
+    (``None`` = open, covering all remaining z); ``ft`` is the GSParams
+    folding_threshold applied to fit kernels for scenes in the tier. Tiers
+    are stored sorted by ``z_max`` ascending with the open (None) tier last;
+    validation lives in ``_validate_folding_tiers``.
+    """
+
+    z_max: Optional[float]
+    ft: float
+
+
+def _validate_folding_tiers(
+    tiers: Tuple['FoldingThresholdTier', ...], context: str
+) -> None:
+    """Validate a fit-kernel folding_threshold tier schedule.
+
+    Enforces: non-empty; every ``ft`` a float in (0, 1); the final tier open
+    (``z_max is None``) and no earlier tier open; bounded ``z_max`` values
+    positive floats and strictly increasing. Together these guarantee the
+    schedule covers every non-negative z exactly once.
+    """
+    if not tiers:
+        raise ValueError(f"{context}: folding_threshold_tiers must be non-empty")
+    for i, tier in enumerate(tiers):
+        if not isinstance(tier.ft, float) or not (0.0 < tier.ft < 1.0):
+            raise ValueError(
+                f"{context}: tier {i} ft must be a float in (0, 1), got " f"{tier.ft!r}"
+            )
+        is_last = i == len(tiers) - 1
+        if is_last:
+            if tier.z_max is not None:
+                raise ValueError(
+                    f"{context}: final tier must have z_max: null (open upper "
+                    f"bound covering all remaining z), got {tier.z_max!r}"
+                )
+        else:
+            if tier.z_max is None:
+                raise ValueError(
+                    f"{context}: only the final tier may have z_max: null; "
+                    f"tier {i} of {len(tiers)} has null z_max"
+                )
+            if not isinstance(tier.z_max, float) or tier.z_max <= 0:
+                raise ValueError(
+                    f"{context}: tier {i} z_max must be a positive float, got "
+                    f"{tier.z_max!r}"
+                )
+    bounded = [t.z_max for t in tiers[:-1]]
+    if any(b2 <= b1 for b1, b2 in zip(bounded, bounded[1:])):
+        raise ValueError(
+            f"{context}: tier z_max values must be strictly increasing, got "
+            f"{bounded}"
+        )
+
+
+@dataclass(frozen=True)
 class PSFSpec:
     """One channel's PSF specification (a broadband band or the grism).
 
     ``gaussian`` carries ``fwhm_arcsec``; ``roman_wfi`` (realistic WFI PSF
     via ``galsim.roman.getPSF``, monochromatic) carries ``sca`` and
-    ``pupil_bin``, plus two optional GSParams folding thresholds (None keeps
+    ``pupil_bin``, plus optional GSParams folding thresholds (None keeps
     GalSim's default 5e-3). A looser threshold shrinks the rendered kernel
     stamp -- and with it the padded convolution FFT -- at the cost of
     truncating more far-wing flux.
 
-    ``folding_threshold`` applies to the FIT-model kernels (the per-eval
-    convolution cost); ``mock_folding_threshold`` applies to the TRUTH
+    The FIT-model kernels (the per-eval convolution cost) take their
+    folding_threshold from EITHER ``folding_threshold`` (a single value for
+    all z) OR ``folding_threshold_tiers`` (a redshift schedule); the two are
+    mutually exclusive. ``mock_folding_threshold`` applies to the TRUTH
     (mock-data) render kernels, paid once per fit. Leaving
-    ``mock_folding_threshold`` at None while loosening ``folding_threshold``
+    ``mock_folding_threshold`` at None while loosening the fit threshold
     gives the realistic asymmetry: mock data is rendered at higher kernel
     fidelity than the inference model. The mock kernels must be at least as
-    accurate as the fit kernels (raises otherwise). Parameter-level bias
+    accurate as the fit kernels at every z (raises otherwise; with tiers the
+    binding tier is the most accurate = smallest ft). Parameter-level bias
     from the split was gated at folding_threshold=0.01 (all MAP shifts
-    <= 0.07 sigma vs a matched-kernel control at line SNR 100); 0.02 fails
-    that gate. Cross-type fields must be None (raises otherwise).
+    <= 0.07 sigma vs a matched-kernel control at line SNR 100) for z <= 1.2;
+    the rigor audit found the shape/shear/continuum wing-truncation bias
+    grows with kernel size and exceeds that envelope by z=1.9 (cosi -0.093,
+    g1 -0.037, continuum -0.066), motivating the tiered schedule (looser ft
+    at low z, tighter at high z). 0.02 fails the gate at all z. Cross-type
+    fields must be None (raises otherwise).
     """
 
     psf_type: str
     fwhm_arcsec: Optional[float] = None  # gaussian only, arcsec
     sca: Optional[int] = None  # roman_wfi only, 1-18
     pupil_bin: Optional[int] = None  # roman_wfi only
-    folding_threshold: Optional[float] = None  # roman_wfi only, fit kernels
+    folding_threshold: Optional[float] = None  # roman_wfi only, fit kernels (scalar)
     mock_folding_threshold: Optional[float] = None  # roman_wfi only, truth kernels
+    # roman_wfi only, fit kernels (z schedule); mutually exclusive with
+    # folding_threshold
+    folding_threshold_tiers: Optional[Tuple[FoldingThresholdTier, ...]] = None
 
     def __post_init__(self):
         if self.psf_type == 'gaussian':
@@ -92,10 +161,11 @@ class PSFSpec:
             if (
                 self.folding_threshold is not None
                 or self.mock_folding_threshold is not None
+                or self.folding_threshold_tiers is not None
             ):
                 raise ValueError(
-                    "folding_threshold/mock_folding_threshold are "
-                    "roman_wfi-only psf fields"
+                    "folding_threshold/mock_folding_threshold/"
+                    "folding_threshold_tiers are roman_wfi-only psf fields"
                 )
         elif self.psf_type == 'roman_wfi':
             if self.fwhm_arcsec is not None:
@@ -109,37 +179,89 @@ class PSFSpec:
                     f"roman_wfi pupil_bin must be a positive int, got "
                     f"{self.pupil_bin!r}"
                 )
-            for name in ('folding_threshold', 'mock_folding_threshold'):
-                ft = getattr(self, name)
-                if ft is not None and (
-                    not isinstance(ft, float) or not (0.0 < ft < 1.0)
-                ):
-                    raise ValueError(
-                        f"roman_wfi {name} must be a float in (0, 1), got {ft!r}"
-                    )
-            # mock kernels must be at least as accurate as fit kernels
-            # (None = galsim default 5e-3)
+            if self.folding_threshold is not None and (
+                not isinstance(self.folding_threshold, float)
+                or not (0.0 < self.folding_threshold < 1.0)
+            ):
+                raise ValueError(
+                    f"roman_wfi folding_threshold must be a float in (0, 1), "
+                    f"got {self.folding_threshold!r}"
+                )
+            if self.mock_folding_threshold is not None and (
+                not isinstance(self.mock_folding_threshold, float)
+                or not (0.0 < self.mock_folding_threshold < 1.0)
+            ):
+                raise ValueError(
+                    f"roman_wfi mock_folding_threshold must be a float in "
+                    f"(0, 1), got {self.mock_folding_threshold!r}"
+                )
+            if (
+                self.folding_threshold is not None
+                and self.folding_threshold_tiers is not None
+            ):
+                raise ValueError(
+                    "folding_threshold (scalar) and folding_threshold_tiers "
+                    "(z schedule) are mutually exclusive; set at most one"
+                )
+            if self.folding_threshold_tiers is not None:
+                _validate_folding_tiers(
+                    self.folding_threshold_tiers, "roman_wfi folding_threshold_tiers"
+                )
+            # mock kernels must be at least as accurate as fit kernels at every
+            # z (None = galsim default 5e-3). With a tier schedule the binding
+            # fit tier is the most accurate one (smallest ft).
             mock_eff = (
                 self.mock_folding_threshold
                 if self.mock_folding_threshold is not None
                 else _GALSIM_DEFAULT_FOLDING_THRESHOLD
             )
-            fit_eff = (
-                self.folding_threshold
-                if self.folding_threshold is not None
-                else _GALSIM_DEFAULT_FOLDING_THRESHOLD
-            )
-            if mock_eff > fit_eff:
+            if self.folding_threshold_tiers is not None:
+                fit_eff_most_accurate = min(t.ft for t in self.folding_threshold_tiers)
+            else:
+                fit_eff_most_accurate = (
+                    self.folding_threshold
+                    if self.folding_threshold is not None
+                    else _GALSIM_DEFAULT_FOLDING_THRESHOLD
+                )
+            if mock_eff > fit_eff_most_accurate:
                 raise ValueError(
-                    f"mock_folding_threshold ({mock_eff}) must be <= the fit "
-                    f"folding_threshold ({fit_eff}): truth-render kernels "
-                    f"must be at least as accurate as fit kernels"
+                    f"mock_folding_threshold ({mock_eff}) must be <= the most "
+                    f"accurate fit folding_threshold ({fit_eff_most_accurate}): "
+                    f"truth-render kernels must be at least as accurate as fit "
+                    f"kernels at every z"
                 )
         else:
             raise NotImplementedError(
                 f"psf type {self.psf_type!r} not supported; supported types: "
                 f"{list(_PSF_TYPES)}"
             )
+
+    def resolve_fit_folding_threshold(self, z: float) -> Optional[float]:
+        """Fit-kernel folding_threshold at scene redshift ``z``.
+
+        Returns the scalar ``folding_threshold`` (z-independent) when no tier
+        schedule is configured, else the ``ft`` of the first tier whose
+        ``z_max`` covers ``z`` (tiers sorted ascending; the final open tier
+        covers all remaining z). ``None`` means GalSim's default (5e-3).
+        """
+        if self.folding_threshold_tiers is None:
+            return self.folding_threshold
+        if (
+            not isinstance(z, (int, float))
+            or isinstance(z, bool)
+            or not math.isfinite(float(z))
+        ):
+            raise ValueError(
+                f"folding_threshold tier resolution needs a finite numeric z, "
+                f"got {z!r}"
+            )
+        for tier in self.folding_threshold_tiers:
+            if tier.z_max is None or z <= tier.z_max:
+                return tier.ft
+        # unreachable when tiers are validated (final tier is open)
+        raise ValueError(
+            f"no folding_threshold tier covers z={z}; tiers={self.folding_threshold_tiers}"
+        )
 
 
 def _require_yaml_int(block: dict, key: str, default: int, context: str) -> int:
@@ -153,10 +275,54 @@ def _require_yaml_int(block: dict, key: str, default: int, context: str) -> int:
     return val
 
 
+def _parse_folding_tiers(
+    block: dict, context: str
+) -> Optional[Tuple[FoldingThresholdTier, ...]]:
+    """Parse an optional folding_threshold_tiers list from a psf YAML block.
+
+    Each entry is a ``{z_max, ft}`` mapping (``z_max: null`` for the final
+    open tier). Returns None when the key is absent. Structural validation
+    (ordering, open-final, ft range) happens in the PSFSpec constructor.
+    """
+    tiers_raw = block.get('folding_threshold_tiers')
+    if tiers_raw is None:
+        return None
+    if not isinstance(tiers_raw, list) or not tiers_raw:
+        raise ValueError(
+            f"{context}: folding_threshold_tiers must be a non-empty list of "
+            f"{{z_max, ft}} mappings, got {tiers_raw!r}"
+        )
+    parsed = []
+    for i, entry in enumerate(tiers_raw):
+        entry_ctx = f"{context}:folding_threshold_tiers[{i}]"
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"{entry_ctx}: each tier must be a {{z_max, ft}} mapping, got "
+                f"{entry!r}"
+            )
+        _reject_unknown(entry, ('z_max', 'ft'), entry_ctx)
+        _require_keys(entry, ('z_max', 'ft'), entry_ctx)
+        z_max = entry['z_max']
+        parsed.append(
+            FoldingThresholdTier(
+                z_max=float(z_max) if z_max is not None else None,
+                ft=float(entry['ft']),
+            )
+        )
+    return tuple(parsed)
+
+
 def _parse_roman_wfi_psf(block: dict, context: str) -> PSFSpec:
     _reject_unknown(
         block,
-        ('type', 'sca', 'pupil_bin', 'folding_threshold', 'mock_folding_threshold'),
+        (
+            'type',
+            'sca',
+            'pupil_bin',
+            'folding_threshold',
+            'mock_folding_threshold',
+            'folding_threshold_tiers',
+        ),
         context,
     )
     thresholds = {}
@@ -169,6 +335,7 @@ def _parse_roman_wfi_psf(block: dict, context: str) -> PSFSpec:
         pupil_bin=_require_yaml_int(
             block, 'pupil_bin', _ROMAN_WFI_DEFAULT_PUPIL_BIN, context
         ),
+        folding_threshold_tiers=_parse_folding_tiers(block, context),
         **thresholds,
     )
 

--- a/kl_pipe/observation.py
+++ b/kl_pipe/observation.py
@@ -618,6 +618,31 @@ def _fine_pixel_response_fft(fine_image_pars, coarse_pixel_scale):
     return BoxPixel(coarse_pixel_scale).ft(KX, KY)
 
 
+def _validate_psf_kernel_size_args(
+    psf_kernel_size: Optional[int], psf, rc_was_default: bool
+) -> None:
+    """Guard psf_kernel_size usage in the obs builders.
+
+    A pinned kernel size is meaningless without a PSF, and it is defined in
+    fine-scale pixels (pixel_scale / oversample), so it must be tied to an
+    explicitly chosen render_config: builder-default configs are rebuilt by
+    ``InferenceTask`` at a priors-derived oversample via
+    ``with_render_config``, which does not carry the pinned size and would
+    silently drop it.
+    """
+    if psf_kernel_size is None:
+        return
+    if psf is None:
+        raise ValueError("psf_kernel_size given without a psf")
+    if rc_was_default:
+        raise ValueError(
+            "psf_kernel_size requires an explicit render_config; the "
+            "builder-default render_config is rebuilt by InferenceTask via "
+            "with_render_config, which would silently drop the pinned "
+            "kernel size"
+        )
+
+
 def build_image_obs(
     image_pars: ImagePars,
     *,
@@ -630,6 +655,7 @@ def build_image_obs(
     pixel_response=_PIXEL_RESPONSE_UNSET,
     render_config=None,
     broadband_key: Optional[str] = None,
+    psf_kernel_size: Optional[int] = None,
 ) -> ImageObs:
     """Build imaging observation. Replaces Model.configure_psf().
 
@@ -663,11 +689,19 @@ def build_image_obs(
         priors-sized rc and rebuild the obs internally. For bespoke
         (non-inference) rendering with tight priors, pass an explicit
         ``build_image_render_config(...)`` result.
+    psf_kernel_size : int, optional
+        Explicit PSF kernel stamp size in fine-scale pixels
+        (``pixel_scale / oversample``), passed to ``precompute_psf_fft``.
+        Pins the kernel array shape (odd, >= automatic good size; raises
+        otherwise). Requires an explicit ``render_config``: the
+        builder-default config is rebuilt by ``InferenceTask`` via
+        ``with_render_config``, which would silently drop the pinned size.
     """
     rc_was_default = render_config is None
     if rc_was_default:
         render_config = RenderConfig(oversample=DEFAULT_OVERSAMPLE)
     oversample = render_config.oversample
+    _validate_psf_kernel_size_args(psf_kernel_size, psf, rc_was_default)
 
     X, Y = build_map_grid_from_image_pars(image_pars)
 
@@ -688,6 +722,7 @@ def build_image_obs(
             image_pars=image_pars,
             oversample=oversample,
             gsparams=gsparams,
+            kernel_size=psf_kernel_size,
         )
 
         # fused k-space PSF kernel for k-space intensity models
@@ -897,6 +932,7 @@ def build_grism_obs(
     velocity_window_kms: float = 3000.0,
     n_lambda: Optional[int] = None,
     slice_width_kms: Optional[float] = None,
+    psf_kernel_size: Optional[int] = None,
 ) -> GrismObs:
     """Build grism observation.
 
@@ -943,11 +979,21 @@ def build_grism_obs(
         largest line-of-sight velocity span the priors allow -- about 40
         km/s for vcirc priors reaching ~300 km/s, 60-80 km/s for
         exploration. Mutually exclusive with ``n_lambda``.
+    psf_kernel_size : int, optional
+        Explicit PSF kernel stamp size in fine-scale pixels
+        (``pixel_scale / oversample``), passed to ``precompute_psf_fft``.
+        Pins the kernel array shape (odd, >= automatic good size; raises
+        otherwise) -- e.g. to keep wavelength-dependent PSF kernels at one
+        shape across an ensemble of redshifts. Requires an explicit
+        ``render_config``: the builder-default config is rebuilt by
+        ``InferenceTask`` via ``with_render_config``, which would silently
+        drop the pinned size.
     """
     rc_was_default = render_config is None
     if rc_was_default:
         render_config = RenderConfig(oversample=DEFAULT_OVERSAMPLE)
     oversample = render_config.oversample  # canonical
+    _validate_psf_kernel_size_args(psf_kernel_size, psf, rc_was_default)
 
     cube_pars = grism_pars.to_cube_pars(
         z,
@@ -968,6 +1014,7 @@ def build_grism_obs(
             image_pars=cube_pars.image_pars,
             oversample=oversample,
             gsparams=gsparams,
+            kernel_size=psf_kernel_size,
         )
 
     # fine grid: create when oversample > 1, regardless of PSF. The BoxPixel

--- a/kl_pipe/observation.py
+++ b/kl_pipe/observation.py
@@ -105,6 +105,9 @@ class ImageObs:
     kspace_psf_fft: Optional[jnp.ndarray] = None
     pixel_response: Optional[PixelResponse] = None
     psf: Optional[object] = None  # galsim.GSObject; static aux for grid validation
+    # psf_kernel_size: pinned kernel stamp size (fine pixels); preserved by
+    # with_render_config so rebuilds keep the pinned shape. None = auto size.
+    psf_kernel_size: Optional[int] = None
     # broadband_key: key into source.broadband_models that this obs renders
     # (used by SourceModel-based inference; None for rendering-only obs).
     broadband_key: Optional[str] = None
@@ -168,6 +171,7 @@ class ImageObs:
                 self.psf,
                 image_pars=self.image_pars,
                 oversample=oversample,
+                kernel_size=self.psf_kernel_size,
             )
 
             if int_model is not None and hasattr(int_model, '_kspace_pad_factor'):
@@ -284,6 +288,9 @@ class GrismObs:
     mask: Optional[jnp.ndarray] = None
     pixel_response_fft: Optional[jnp.ndarray] = None
     psf: Optional[object] = None  # galsim.GSObject; static aux for grid validation
+    # psf_kernel_size: pinned kernel stamp size (fine pixels); preserved by
+    # with_render_config so rebuilds keep the pinned shape. None = auto size.
+    psf_kernel_size: Optional[int] = None
     # _rc_was_default: internal flag — True when build_grism_obs supplied the
     # default render_config (caller passed render_config=None), False when the
     # caller passed an explicit one. Read by InferenceTask.from_obs to decide
@@ -387,6 +394,7 @@ class GrismObs:
                 self.psf,
                 image_pars=self.cube_pars.image_pars,
                 oversample=oversample,
+                kernel_size=self.psf_kernel_size,
             )
 
         if oversample > 1:
@@ -428,6 +436,7 @@ def _image_obs_flatten(obs):
         obs.psf,
         obs.broadband_key,
         obs._rc_was_default,
+        obs.psf_kernel_size,
     )
     return children, aux
 
@@ -448,6 +457,7 @@ def _image_obs_unflatten(aux, children):
         pixel_response=children[9],
         psf=aux[2],
         broadband_key=aux[3],
+        psf_kernel_size=aux[5],
     )
     # _rc_was_default is field(init=False); restore via frozen-dataclass bypass.
     object.__setattr__(obs, '_rc_was_default', aux[4])
@@ -527,6 +537,7 @@ def _grism_obs_flatten(obs):
         obs.fine_image_pars,
         obs.psf,
         obs._rc_was_default,
+        obs.psf_kernel_size,
     )
     return children, aux
 
@@ -543,6 +554,7 @@ def _grism_obs_unflatten(aux, children):
         mask=children[3],
         pixel_response_fft=children[4],
         psf=aux[4],
+        psf_kernel_size=aux[6],
     )
     object.__setattr__(obs, '_rc_was_default', aux[5])
     return obs
@@ -627,8 +639,11 @@ def _validate_psf_kernel_size_args(
     fine-scale pixels (pixel_scale / oversample), so it must be tied to an
     explicitly chosen render_config: builder-default configs are rebuilt by
     ``InferenceTask`` at a priors-derived oversample via
-    ``with_render_config``, which does not carry the pinned size and would
-    silently drop it.
+    ``with_render_config``, which preserves the pinned size but at a
+    DIFFERENT fine pixel scale -- the pinned pixel count would then denote a
+    different angular size than the caller computed. Explicit-rc rebuilds
+    (e.g. the analytic-path line_window_halfwidth fill) keep the oversample,
+    so preserving the pinned size there is exact.
     """
     if psf_kernel_size is None:
         return
@@ -763,6 +778,7 @@ def build_image_obs(
         kspace_psf_fft=kspace_psf_fft,
         pixel_response=pixel_response,
         psf=psf,
+        psf_kernel_size=psf_kernel_size,
         broadband_key=broadband_key,
     )
     # _rc_was_default is field(init=False) so it stays out of the constructor
@@ -1039,6 +1055,7 @@ def build_grism_obs(
         mask=mask,
         pixel_response_fft=pixel_response_fft,
         psf=psf,
+        psf_kernel_size=psf_kernel_size,
     )
     # _rc_was_default is field(init=False) so it stays out of the constructor
     # kwargs; set it here via the standard frozen-dataclass escape hatch.

--- a/kl_pipe/observation.py
+++ b/kl_pipe/observation.py
@@ -653,8 +653,10 @@ def _validate_psf_kernel_size_args(
         raise ValueError(
             "psf_kernel_size requires an explicit render_config; the "
             "builder-default render_config is rebuilt by InferenceTask via "
-            "with_render_config, which would silently drop the pinned "
-            "kernel size"
+            "with_render_config at a priors-derived oversample, which "
+            "preserves the pinned pixel count but at a different fine pixel "
+            "scale -- so the same count would denote a different angular "
+            "size than the caller computed"
         )
 
 
@@ -710,7 +712,9 @@ def build_image_obs(
         Pins the kernel array shape (odd, >= automatic good size; raises
         otherwise). Requires an explicit ``render_config``: the
         builder-default config is rebuilt by ``InferenceTask`` via
-        ``with_render_config``, which would silently drop the pinned size.
+        ``with_render_config`` at a priors-derived oversample, which
+        preserves the pinned pixel count but at a different fine pixel
+        scale, so the same count would denote a different angular size.
     """
     rc_was_default = render_config is None
     if rc_was_default:

--- a/kl_pipe/psf.py
+++ b/kl_pipe/psf.py
@@ -41,7 +41,9 @@ if TYPE_CHECKING:
 class PSFData:
     """Pre-computed PSF arrays for JAX FFT convolution."""
 
-    kernel_fft: jnp.ndarray  # pre-rFFT'd kernel (padded); shape (P, P//2+1)
+    kernel_fft: (
+        jnp.ndarray
+    )  # pre-rFFT'd kernel (padded); shape (Nrow_pad, Ncol_pad//2 + 1)
     padded_shape: tuple  # (Nrow_pad, Ncol_pad) — fine-scale when oversampled
     original_shape: tuple  # (Nrow, Ncol) — fine-scale when oversampled
     oversample: int  # oversampling factor (1 = no oversampling)

--- a/kl_pipe/psf.py
+++ b/kl_pipe/psf.py
@@ -82,6 +82,7 @@ def gsobj_to_kernel(
     image_shape: Tuple[int, int] = None,
     pixel_scale: float = None,
     gsparams: 'galsim.GSParams' = None,
+    kernel_size: int = None,
 ) -> Tuple[np.ndarray, tuple]:
     """
     Convert galsim.GSObject to a normalized, FFT-ready numpy kernel.
@@ -104,6 +105,12 @@ def gsobj_to_kernel(
         Override GSParams for kernel rendering. Controls truncation radius
         (folding_threshold) and accuracy. Default None uses the GSObject's
         own GSParams.
+    kernel_size : int, optional
+        Explicit kernel stamp size (pixels at ``pixel_scale``), overriding
+        GalSim's automatic good image size. Must be an odd int and at least
+        the automatic size -- a smaller value would truncate the PSF and
+        raises. Use to pin the kernel array shape across a set of PSFs
+        whose automatic sizes differ (e.g. wavelength-dependent PSFs).
 
     Returns
     -------
@@ -135,6 +142,21 @@ def gsobj_to_kernel(
     # ensure odd so center pixel is well-defined
     if kern_size % 2 == 0:
         kern_size += 1
+
+    # explicit size override: never truncate below the automatic good size
+    if kernel_size is not None:
+        if not isinstance(kernel_size, (int, np.integer)) or kernel_size % 2 == 0:
+            raise ValueError(
+                f"kernel_size must be an odd positive int, got {kernel_size!r}"
+            )
+        if kernel_size < kern_size:
+            raise ValueError(
+                f"explicit kernel_size ({kernel_size}) is smaller than "
+                f"GalSim's good image size ({kern_size}) at "
+                f"pixel_scale={pixel_scale}; this would truncate the PSF. "
+                f"Increase kernel_size."
+            )
+        kern_size = int(kernel_size)
 
     # render PSF kernel (pixel-integrated via default method)
     kern_img = gsobj.drawImage(nx=kern_size, ny=kern_size, scale=pixel_scale)
@@ -224,6 +246,7 @@ def precompute_psf_fft(
     pixel_scale: float = None,
     oversample: int = 1,
     gsparams: 'galsim.GSParams' = None,
+    kernel_size: int = None,
 ) -> PSFData:
     """
     Full PSF setup: GSObject -> JAX-ready PSFData.
@@ -252,6 +275,12 @@ def precompute_psf_fft(
     gsparams : galsim.GSParams, optional
         Override GSParams for kernel rendering. Controls truncation radius
         (folding_threshold) and accuracy. Passed through to gsobj_to_kernel.
+    kernel_size : int, optional
+        Explicit kernel stamp size in FINE-scale pixels (i.e. at
+        ``pixel_scale / oversample`` when oversampled). Passed through to
+        ``gsobj_to_kernel``; must be odd and at least the automatic good
+        image size (raises otherwise). Pins the kernel (and padded FFT)
+        shape across PSFs whose automatic sizes differ.
 
     Returns
     -------
@@ -293,6 +322,7 @@ def precompute_psf_fft(
         image_shape=fine_shape,
         pixel_scale=fine_pixel_scale,
         gsparams=gsparams,
+        kernel_size=kernel_size,
     )
     kernel_fft = jnp.fft.fft2(jnp.array(kernel_shifted))
 

--- a/kl_pipe/psf.py
+++ b/kl_pipe/psf.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 class PSFData:
     """Pre-computed PSF arrays for JAX FFT convolution."""
 
-    kernel_fft: jnp.ndarray  # pre-FFT'd kernel (padded)
+    kernel_fft: jnp.ndarray  # pre-rFFT'd kernel (padded); shape (P, P//2+1)
     padded_shape: tuple  # (Nrow_pad, Ncol_pad) — fine-scale when oversampled
     original_shape: tuple  # (Nrow, Ncol) — fine-scale when oversampled
     oversample: int  # oversampling factor (1 = no oversampling)
@@ -112,12 +112,25 @@ def gsobj_to_kernel(
         raises. Use to pin the kernel array shape across a set of PSFs
         whose automatic sizes differ (e.g. wavelength-dependent PSFs).
 
+    Padding
+    -------
+    The kernel is placed on the minimum FFT grid for which the circular
+    convolution equals the linear convolution EXACTLY on the retained
+    ``[0, N)`` crop (the only region any caller keeps): with a centered
+    kernel of half-width ``H = K//2`` and corner-placed image, wrap-around
+    only touches output pixels with ``|y - x| >= P - H``, and ``P >= N + H``
+    pushes that past the crop. Kernel tails that exceed the padded grid are
+    folded modulo ``P``, which is exact under the same condition. For
+    kernels much wider than the image (e.g. Roman WFI wings) this shrinks
+    the FFT grid several-fold at zero accuracy cost relative to the classic
+    ``N + K - 1`` full-linear padding.
+
     Returns
     -------
     kernel_shifted : np.ndarray
-        ifftshift'd, zero-padded kernel ready for FFT.
+        Wrapped (modulo-P), minimally-padded kernel ready for FFT.
     padded_shape : tuple
-        (Nrow_pad, Ncol_pad) after padding for linear (non-circular) convolution.
+        (Nrow_pad, Ncol_pad) of the minimal exact FFT grid.
     """
     import galsim as gs
 
@@ -165,19 +178,21 @@ def gsobj_to_kernel(
     # normalize to unit sum
     kernel /= kernel.sum()
 
-    # compute padded shape for linear convolution (avoid wrap-around)
-    nrow_pad = next_fast_len(image_shape[0] + kernel.shape[0] - 1)
-    ncol_pad = next_fast_len(image_shape[1] + kernel.shape[1] - 1)
-    padded_shape = (nrow_pad, ncol_pad)
-
-    # zero-pad kernel then roll center to (0,0) for FFT convention.
-    # np.roll correctly wraps negative-offset values to the end of
-    # the padded array, unlike ifftshift+place which mispositions them.
-    padded_kernel = np.zeros(padded_shape, dtype=np.float64)
-    padded_kernel[: kernel.shape[0], : kernel.shape[1]] = kernel
     row_half = kernel.shape[0] // 2
     col_half = kernel.shape[1] // 2
-    padded_kernel = np.roll(padded_kernel, (-row_half, -col_half), axis=(0, 1))
+
+    # minimum padding exact on the retained [0, N) crop (see docstring)
+    nrow_pad = next_fast_len(image_shape[0] + row_half)
+    ncol_pad = next_fast_len(image_shape[1] + col_half)
+    padded_shape = (nrow_pad, ncol_pad)
+
+    # wrapped (modulo-P) kernel placement with center at (0,0): folds any
+    # kernel tails that exceed the padded grid (np.add.at accumulates
+    # colliding entries). Exact on the retained crop under P >= N + H.
+    padded_kernel = np.zeros(padded_shape, dtype=np.float64)
+    idx_r = (np.arange(kernel.shape[0]) - row_half) % nrow_pad
+    idx_c = (np.arange(kernel.shape[1]) - col_half) % ncol_pad
+    np.add.at(padded_kernel, (idx_r[:, None], idx_c[None, :]), kernel)
 
     return padded_kernel, padded_shape
 
@@ -324,7 +339,9 @@ def precompute_psf_fft(
         gsparams=gsparams,
         kernel_size=kernel_size,
     )
-    kernel_fft = jnp.fft.fft2(jnp.array(kernel_shifted))
+    # rfft2: the kernel and every convolved image are real, so the
+    # half-spectrum transform halves the FFT work at identical values
+    kernel_fft = jnp.fft.rfft2(jnp.array(kernel_shifted))
 
     return PSFData(
         kernel_fft=kernel_fft,
@@ -363,11 +380,11 @@ def _convolve_fft_raw(image: jnp.ndarray, psf_data: PSFData) -> jnp.ndarray:
     padded = jnp.zeros((prow, pcol), dtype=image.dtype)
     padded = padded.at[:nrow, :ncol].set(image)
 
-    # FFT multiply IFFT
-    result = jnp.fft.ifft2(jnp.fft.fft2(padded) * psf_data.kernel_fft)
+    # real-input FFT multiply inverse (kernel_fft is rfft2'd)
+    result = jnp.fft.irfft2(jnp.fft.rfft2(padded) * psf_data.kernel_fft, s=(prow, pcol))
 
-    # crop to original shape and take real part
-    return result[:nrow, :ncol].real
+    # crop to original shape
+    return result[:nrow, :ncol]
 
 
 def convolve_fft(

--- a/kl_pipe/render.py
+++ b/kl_pipe/render.py
@@ -534,6 +534,13 @@ def compute_effective_maxk(
         psf_ft = np.array(
             [abs(psf.kValue(galsim.PositionD(0.0, float(k)))) for k in k_scan]
         )
+        # kValue beyond the profile's own band limit (psf.maxk) is
+        # interpolation noise, not signal: pupil-plane PSFs (e.g.
+        # galsim.roman getPSF) are backed by interpolated images whose
+        # kValue sidelobes bounce back above threshold past the physical
+        # aperture cutoff, which would inflate the scan result and demand
+        # absurd oversampling. Treat the FT as zero past maxk.
+        psf_ft = np.where(k_scan <= float(psf.maxk), psf_ft, 0.0)
         product = product * psf_ft
 
     above = k_scan[product > threshold]
@@ -630,8 +637,14 @@ def compute_effective_maxk_grism(
 
     # PSF damping: post-PSF amplitude at k is bounded by FT[PSF](k). Find the
     # largest k <= k_cube_bare at which FT[PSF] remains above threshold.
+    # The scan stops at the PSF's own band limit (psf.maxk): kValue beyond it
+    # is interpolation noise, not signal -- pupil-plane PSFs (e.g.
+    # galsim.roman getPSF) are backed by interpolated images whose kValue
+    # sidelobes bounce back above threshold past the physical aperture
+    # cutoff, which would inflate the scan result and demand absurd
+    # oversampling.
     n_scan = 500
-    k_scan = np.linspace(0.0, k_cube_bare, n_scan)
+    k_scan = np.linspace(0.0, min(k_cube_bare, float(psf.maxk)), n_scan)
 
     import galsim
 

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -27,7 +27,12 @@ from kl_pipe.ensemble.expander import (
 )
 from kl_pipe.ensemble.mocks import build_fit_inputs
 from kl_pipe.ensemble.scene import scene_priors, scene_truth_defaults
-from kl_pipe.ensemble.spec import EnsembleSpec, ObservingConfig
+from kl_pipe.ensemble.spec import (
+    EnsembleSpec,
+    FoldingThresholdTier,
+    ObservingConfig,
+    PSFSpec,
+)
 from kl_pipe.priors import LogNormal, Uniform
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -146,6 +151,177 @@ class TestObservingConfig:
         assert config.grism_rolls_deg == (0.0, 45.0, 90.0, 135.0)
         assert config.grism_psf.psf_type == 'roman_wfi'
         assert all(psf.psf_type == 'roman_wfi' for psf in config.band_psf.values())
+
+
+# ==============================================================================
+# z-tiered fit folding_threshold (PSFSpec.folding_threshold_tiers)
+# ==============================================================================
+
+
+class TestFoldingThresholdTiers:
+    """The z-tiered fit-kernel folding_threshold schedule and its validation.
+
+    The rigor audit (docs/sessions/2026-07-18_roman_psf_rigor_audit.md) found
+    ft=0.01 fit kernels safe for z <= 1.2 but wing-truncation-biased at z=1.9;
+    the ruling is a two-tier schedule (ft=0.01 for z<=1.2, ft=5e-3 above). At
+    the tight tier ft == the mock default 5e-3, so mock == fit by construction.
+    """
+
+    def _roman_block(self, **overrides) -> dict:
+        block = {'type': 'roman_wfi', 'sca': 10, 'pupil_bin': 4}
+        block.update(overrides)
+        return block
+
+    def _load_grism_psf(self, tmp_path, grism_block) -> PSFSpec:
+        raw = yaml.safe_load((REGISTRY / 'canonical_P_roman.yaml').read_text())
+        raw['psf']['grism'] = grism_block
+        path = tmp_path / 'obs.yaml'
+        path.write_text(yaml.safe_dump(raw))
+        return ObservingConfig.from_yaml(path).grism_psf
+
+    def test_two_tier_resolution(self, tmp_path):
+        # ruling schedule: ft=0.01 for z<=1.2, tighter 5e-3 above
+        block = self._roman_block(
+            folding_threshold_tiers=[
+                {'z_max': 1.2, 'ft': 0.01},
+                {'z_max': None, 'ft': 5.0e-3},
+            ]
+        )
+        psf = self._load_grism_psf(tmp_path, block)
+        assert psf.folding_threshold is None
+        assert len(psf.folding_threshold_tiers) == 2
+        # z <= 1.2 -> loose tier (boundary inclusive)
+        assert psf.resolve_fit_folding_threshold(0.55) == 0.01
+        assert psf.resolve_fit_folding_threshold(1.2) == 0.01
+        # z > 1.2 -> tight tier == mock default (zero mismatch by construction)
+        assert psf.resolve_fit_folding_threshold(1.9) == 5.0e-3
+        assert psf.resolve_fit_folding_threshold(2.5) == 5.0e-3
+
+    def test_scalar_option_unchanged(self, tmp_path):
+        psf = self._load_grism_psf(tmp_path, self._roman_block(folding_threshold=0.01))
+        assert psf.folding_threshold == 0.01
+        assert psf.folding_threshold_tiers is None
+        # scalar is z-independent
+        assert psf.resolve_fit_folding_threshold(0.5) == 0.01
+        assert psf.resolve_fit_folding_threshold(1.9) == 0.01
+        # unset defaults resolve to None (galsim default) at any z
+        default_psf = self._load_grism_psf(tmp_path, self._roman_block())
+        assert default_psf.resolve_fit_folding_threshold(1.9) is None
+
+    def test_scalar_and_tiers_mutually_exclusive(self):
+        with pytest.raises(ValueError, match='mutually exclusive'):
+            PSFSpec(
+                psf_type='roman_wfi',
+                sca=10,
+                pupil_bin=4,
+                folding_threshold=0.01,
+                folding_threshold_tiers=(
+                    FoldingThresholdTier(z_max=1.2, ft=0.01),
+                    FoldingThresholdTier(z_max=None, ft=5.0e-3),
+                ),
+            )
+
+    def test_final_tier_must_be_open(self):
+        with pytest.raises(ValueError, match='final tier must have z_max: null'):
+            PSFSpec(
+                psf_type='roman_wfi',
+                sca=10,
+                pupil_bin=4,
+                folding_threshold_tiers=(
+                    FoldingThresholdTier(z_max=1.2, ft=0.01),
+                    FoldingThresholdTier(z_max=2.0, ft=5.0e-3),
+                ),
+            )
+
+    def test_only_final_tier_may_be_open(self):
+        with pytest.raises(ValueError, match='only the final tier'):
+            PSFSpec(
+                psf_type='roman_wfi',
+                sca=10,
+                pupil_bin=4,
+                folding_threshold_tiers=(
+                    FoldingThresholdTier(z_max=None, ft=0.01),
+                    FoldingThresholdTier(z_max=None, ft=5.0e-3),
+                ),
+            )
+
+    def test_z_max_must_increase(self):
+        with pytest.raises(ValueError, match='strictly increasing'):
+            PSFSpec(
+                psf_type='roman_wfi',
+                sca=10,
+                pupil_bin=4,
+                folding_threshold_tiers=(
+                    FoldingThresholdTier(z_max=1.5, ft=0.01),
+                    FoldingThresholdTier(z_max=1.2, ft=8.0e-3),
+                    FoldingThresholdTier(z_max=None, ft=5.0e-3),
+                ),
+            )
+
+    def test_tier_ft_out_of_range_rejected(self):
+        with pytest.raises(ValueError, match='ft must be a float in'):
+            PSFSpec(
+                psf_type='roman_wfi',
+                sca=10,
+                pupil_bin=4,
+                folding_threshold_tiers=(
+                    FoldingThresholdTier(z_max=1.2, ft=1.5),
+                    FoldingThresholdTier(z_max=None, ft=5.0e-3),
+                ),
+            )
+
+    def test_mock_must_be_at_least_as_accurate_as_tightest_tier(self):
+        # mock (0.008) looser than the tight tier ft (5e-3) -> mock less
+        # accurate than the fit at high z -> reject
+        with pytest.raises(ValueError, match='at least as accurate'):
+            PSFSpec(
+                psf_type='roman_wfi',
+                sca=10,
+                pupil_bin=4,
+                mock_folding_threshold=8.0e-3,
+                folding_threshold_tiers=(
+                    FoldingThresholdTier(z_max=1.2, ft=0.01),
+                    FoldingThresholdTier(z_max=None, ft=5.0e-3),
+                ),
+            )
+
+    def test_tiers_rejected_for_gaussian(self):
+        with pytest.raises(ValueError, match='roman_wfi-only'):
+            PSFSpec(
+                psf_type='gaussian',
+                fwhm_arcsec=0.18,
+                folding_threshold_tiers=(FoldingThresholdTier(z_max=None, ft=5.0e-3),),
+            )
+
+    def test_resolve_requires_finite_z_for_tiers(self):
+        psf = PSFSpec(
+            psf_type='roman_wfi',
+            sca=10,
+            pupil_bin=4,
+            folding_threshold_tiers=(
+                FoldingThresholdTier(z_max=1.2, ft=0.01),
+                FoldingThresholdTier(z_max=None, ft=5.0e-3),
+            ),
+        )
+        with pytest.raises(ValueError, match='finite numeric z'):
+            psf.resolve_fit_folding_threshold(None)
+
+    def test_yaml_tier_missing_ft_rejected(self, tmp_path):
+        block = self._roman_block(
+            folding_threshold_tiers=[{'z_max': 1.2}, {'z_max': None, 'ft': 5.0e-3}]
+        )
+        with pytest.raises(ValueError, match='missing required keys'):
+            self._load_grism_psf(tmp_path, block)
+
+    def test_yaml_tier_unknown_key_rejected(self, tmp_path):
+        block = self._roman_block(
+            folding_threshold_tiers=[
+                {'z_max': 1.2, 'ft': 0.01, 'bogus': 1},
+                {'z_max': None, 'ft': 5.0e-3},
+            ]
+        )
+        with pytest.raises(ValueError, match='unknown keys'):
+            self._load_grism_psf(tmp_path, block)
 
 
 # ==============================================================================

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -134,6 +134,20 @@ class TestObservingConfig:
         with pytest.raises(NotImplementedError, match='gaussian'):
             ObservingConfig.from_yaml(path)
 
+    def test_gaussian_psf_properties(self, canonical_q):
+        # backward-compat accessors for gaussian configs
+        assert canonical_q.band_psf_fwhm == {'F087': 0.18}
+        assert canonical_q.grism_psf_fwhm == 0.18
+        assert canonical_q.band_psf['F087'].psf_type == 'gaussian'
+        assert canonical_q.grism_psf.psf_type == 'gaussian'
+
+    def test_canonical_p_roman_loads(self):
+        config = ObservingConfig.from_yaml(REGISTRY / 'canonical_P_roman.yaml')
+        assert config.bands == ('H158', 'F184')
+        assert config.grism_rolls_deg == (0.0, 45.0, 90.0, 135.0)
+        assert config.grism_psf.psf_type == 'roman_wfi'
+        assert all(psf.psf_type == 'roman_wfi' for psf in config.band_psf.values())
+
 
 # ==============================================================================
 # Scene

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -134,16 +134,15 @@ class TestObservingConfig:
         with pytest.raises(NotImplementedError, match='gaussian'):
             ObservingConfig.from_yaml(path)
 
-    def test_gaussian_psf_properties(self, canonical_q):
-        # backward-compat accessors for gaussian configs
-        assert canonical_q.band_psf_fwhm == {'F087': 0.18}
-        assert canonical_q.grism_psf_fwhm == 0.18
+    def test_gaussian_psf_specs(self, canonical_q):
         assert canonical_q.band_psf['F087'].psf_type == 'gaussian'
+        assert canonical_q.band_psf['F087'].fwhm_arcsec == 0.18
         assert canonical_q.grism_psf.psf_type == 'gaussian'
+        assert canonical_q.grism_psf.fwhm_arcsec == 0.18
 
     def test_canonical_p_roman_loads(self):
         config = ObservingConfig.from_yaml(REGISTRY / 'canonical_P_roman.yaml')
-        assert config.bands == ('H158', 'F184')
+        assert config.bands == ('F158', 'F184')
         assert config.grism_rolls_deg == (0.0, 45.0, 90.0, 135.0)
         assert config.grism_psf.psf_type == 'roman_wfi'
         assert all(psf.psf_type == 'roman_wfi' for psf in config.band_psf.values())

--- a/tests/test_flagship.py
+++ b/tests/test_flagship.py
@@ -13,10 +13,16 @@ diagnostic plot doubles as a presentation / paper asset. Outputs sort first
 alphabetically in ``tests/out/`` via the ``00_flagship/`` directory.
 
 Configuration (Roman-like), dev config:
-- F087 broadband: 32x32 image at 0.11 arcsec/pixel (native Roman), PSF FWHM 0.18"
+- F087 broadband: 32x32 image at 0.11 arcsec/pixel (native Roman), Roman WFI
+  PSF (galsim.roman.getPSF, monochromatic at the band effective wavelength;
+  SCA 10, pupil_bin 4)
 - Grism (Roman G150-like): 32x32 dispersed image, dispersion 1.1 nm/pix,
   lambda_ref derived from Halpha at z=1.0 (lambda_obs ~ 1313 nm, within the
-  Roman grism range ~1.0-1.93 um)
+  Roman grism range ~1.0-1.93 um); grism PSF at the observed line wavelength
+- Dual PSF fidelity: mock/truth data is rendered with default-accuracy
+  kernels (folding_threshold 5e-3) while the inference model uses
+  folding_threshold 0.01 kernels -- the model PSF never matches reality
+  exactly, and the 0.01 setting is gated at <= 0.07 sigma parameter bias
 - Galaxy: z=1.0, vcirc=200 km/s, hlr~0.3", inc~53 deg (cosi=0.6), theta_int=pi/4
 - Shear: g1=0.02, g2=-0.01
 - SNR (matched-filter): 100 broadband, 150 grism
@@ -66,7 +72,6 @@ import warnings
 from pathlib import Path
 from typing import Dict
 
-import galsim
 import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
@@ -78,6 +83,8 @@ from kl_pipe.diagnostics.imaging import (
     plot_data_comparison_panels,
 )
 from kl_pipe.dispersion import build_grism_pars_for_line
+from kl_pipe.ensemble.mocks import _build_band_psf, _build_grism_psf
+from kl_pipe.ensemble.spec import PSFSpec
 from kl_pipe.intensity import InclinedExponentialModel
 from kl_pipe.lines import EmissionLine, LINE_LAMBDAS
 from kl_pipe.noise import grism_line_noise
@@ -112,10 +119,19 @@ pytestmark = pytest.mark.slow
 Z = 1.0
 PIXEL_SCALE = 0.11  # arcsec/pixel, Roman native
 IMAGE_SHAPE = (32, 32)
-PSF_FWHM = 0.18  # arcsec, Roman-like (F087 broadband / grism)
 SNR_BROADBAND = 100.0
 SNR_GRISM = 150.0
 GRISM_DISPERSION_NM_PER_PIX = 1.1
+
+# Roman WFI PSF (galsim.roman.getPSF, monochromatic; broadband at the band
+# effective wavelength, grism at the observed Halpha wavelength). Mock/truth
+# data uses default-accuracy kernels; the fit model uses folding_threshold
+# 0.01 kernels (2.8x cheaper convolutions, parameter bias gated at <= 0.07
+# sigma against matched kernels -- see test_roman_psf.py fidelity tests).
+PSF_SPEC_MOCK = PSFSpec(psf_type='roman_wfi', sca=10, pupil_bin=4)
+PSF_SPEC_FIT = PSFSpec(
+    psf_type='roman_wfi', sca=10, pupil_bin=4, folding_threshold=0.01
+)
 
 # Tully-Fisher scatter (dex) for the vel.vcirc prior. Fiducial 0.08 dex from
 # Xu+2022 / Pranjal, the project's archival TFR value (ensemble sweep spans
@@ -125,9 +141,10 @@ GRISM_DISPERSION_NM_PER_PIX = 1.1
 SIGMA_TF_DEX = 0.08
 
 # Spatial oversample factor for both broadband and grism obs. Default is 5;
-# 3 is acceptable here because PSF FWHM (0.18") is ~1.6 pixels at 0.11"/pix
-# and the resulting profile is band-limited enough that osf=3 gives sub-1%
-# bias on rendered images. Cuts FFT work ~3x vs default.
+# 3 is acceptable here because the Roman WFI optical PSF is strictly
+# band-limited at the aperture cutoff (2 pi D / lambda ~ 50-82 rad/arcsec
+# over the bands used), inside the oversample-3 fine-grid Nyquist
+# (85.7 rad/arcsec at 0.11"/pix). Cuts FFT work ~3x vs default.
 SPATIAL_OVERSAMPLE = 3
 
 # Sampler settings. Uses the Laplace preconditioner (precondition='laplace'):
@@ -366,23 +383,37 @@ def _band_flat_pars(true: Dict[str, float], band_key: str) -> Dict[str, float]:
     }
 
 
-def _make_broadband_channel(source, true, image_pars, psf, band_key, seed):
+def _make_broadband_channel(
+    source, true, image_pars, psf_mock, psf_fit, band_key, seed
+):
     """Broadband channel: GalSim SyntheticIntensity data + obs carrying it.
 
     Synthetic data is rendered by GalSim (an independent renderer), not the
     model under test -- the flagship's cross-check against the forward model.
-    Returns a channel dict with obs + the true/noisy images + variance.
+    Data uses the mock-fidelity PSF; the fit obs carries the fit-fidelity
+    kernel. Returns a channel dict with obs + true/noisy images + variance.
     """
     int_model = source.broadband_models[band_key]
     synth = SyntheticIntensity(
-        _band_flat_pars(true, band_key), model_type='exponential', seed=seed, psf=psf
+        _band_flat_pars(true, band_key),
+        model_type='exponential',
+        seed=seed,
+        psf=psf_mock,
     )
+    # galsim-native backend: the scipy backend multiplies the PSF FT on the
+    # profile's own FFT grid, which cannot host the Roman PSF's far wings
+    # (kernel larger than the grid raises); galsim convolves natively at
+    # whatever internal size the optics demand
     data_noisy = synth.generate(
-        image_pars, snr=SNR_BROADBAND, seed=seed, include_poisson=False
+        image_pars,
+        snr=SNR_BROADBAND,
+        seed=seed,
+        include_poisson=False,
+        sersic_backend='galsim',
     )
     obs = build_image_obs(
         image_pars,
-        psf=psf,
+        psf=psf_fit,
         render_config=RenderConfig(oversample=SPATIAL_OVERSAMPLE),
         data=jnp.asarray(data_noisy),
         variance=synth.variance,
@@ -398,12 +429,16 @@ def _make_broadband_channel(source, true, image_pars, psf, band_key, seed):
     }
 
 
-def _make_grism_channel(source, true, image_pars, psf, angle_deg, seed, roll_key):
+def _make_grism_channel(
+    source, true, image_pars, psf_mock, psf_fit, angle_deg, seed, roll_key
+):
     """One grism roll: (optionally rotated) WCS obs + model-rendered truth +
     independent Gaussian noise at fixed per-exposure SNR.
 
-    angle_deg == 0 reuses the dev image_pars (default WCS) so the dev config's
-    single roll is unchanged; nonzero angles carry a rotated-WCS ImagePars.
+    Truth is rendered through the mock-fidelity PSF; the fit obs carries the
+    fit-fidelity kernel. angle_deg == 0 reuses the dev image_pars (default
+    WCS) so the dev config's single roll is unchanged; nonzero angles carry
+    a rotated-WCS ImagePars.
     """
     if angle_deg == 0.0:
         ip = image_pars
@@ -419,7 +454,7 @@ def _make_grism_channel(source, true, image_pars, psf, angle_deg, seed, roll_key
         image_pars=ip,
         dispersion=GRISM_DISPERSION_NM_PER_PIX,
     )
-    grism_obs_clean = build_grism_obs(grism_pars, z=Z, psf=psf)
+    grism_obs_clean = build_grism_obs(grism_pars, z=Z, psf=psf_mock)
     data_true = np.asarray(source.render_grism(true, grism_obs_clean))
     # SNR_GRISM is the emission-LINE matched-filter SNR: normalize the noise on
     # the line only (continuum zeroed), not the continuum-inflated whole stamp
@@ -432,7 +467,7 @@ def _make_grism_channel(source, true, image_pars, psf, angle_deg, seed, roll_key
     obs = build_grism_obs(
         grism_pars,
         z=Z,
-        psf=psf,
+        psf=psf_fit,
         render_config=RenderConfig(oversample=SPATIAL_OVERSAMPLE),
         data=jnp.asarray(data_noisy),
         variance=var,
@@ -455,7 +490,8 @@ def _build_config(production: bool):
     images + variance for both inference and diagnostics.
     """
     image_pars = ImagePars(shape=IMAGE_SHAPE, pixel_scale=PIXEL_SCALE, indexing='ij')
-    psf = galsim.Gaussian(fwhm=PSF_FWHM)
+    grism_psf_mock = _build_grism_psf(PSF_SPEC_MOCK, Z)
+    grism_psf_fit = _build_grism_psf(PSF_SPEC_FIT, Z)
 
     def _line_source(broadband_models):
         return SourceModel(
@@ -488,17 +524,26 @@ def _build_config(production: bool):
         roll_angles = (0.0,)
 
     # Distinct noise seeds per channel (independent exposures). Dev keeps its
-    # historical seeds (F087=42, roll0 grism=43) so its data is unchanged.
+    # historical seeds (F087=42, roll0 grism=43) so its noise realization is
+    # unchanged (the data itself moved with the Roman-PSF migration).
     band_seeds = {'F087': 42, 'F158': 52}
     image_channels = {
-        b: _make_broadband_channel(source, true, image_pars, psf, b, band_seeds[b])
+        b: _make_broadband_channel(
+            source,
+            true,
+            image_pars,
+            _build_band_psf(PSF_SPEC_MOCK, b),
+            _build_band_psf(PSF_SPEC_FIT, b),
+            b,
+            band_seeds[b],
+        )
         for b in band_keys
     }
     grism_channels = {}
     for i, a in enumerate(roll_angles):
         seed = 43 if not production else 100 + i
         grism_channels[f'roll{i}'] = _make_grism_channel(
-            source, true, image_pars, psf, a, seed, f'roll{i}'
+            source, true, image_pars, grism_psf_mock, grism_psf_fit, a, seed, f'roll{i}'
         )
     return source, priors, true, image_channels, grism_channels
 

--- a/tests/test_galsim_reference.py
+++ b/tests/test_galsim_reference.py
@@ -281,18 +281,23 @@ class TestGalSimReferenceGate:
         # against the same independent GalSim-chromatic reference. The
         # analytic path is the n_lambda -> infinity limit of the slice
         # method, so it must sit at or below the refined-grid floor.
-        # Measured (2026-07-06, float64, this gate, oversample=5):
-        # max|diff|/peak=0.206%, mean|diff|/peak=0.019% -- well below the
-        # n_lambda=251 slice floor (0.534%/0.030%): removing slice
-        # quantization also removes part of the shift-interpolation
-        # disagreement. Frozen at ~3x measured.
+        # Provenance history: the 2026-07-06 freeze recorded
+        # max|diff|/peak=0.206% and set max_tol=0.006 (~3x). That value is
+        # not reproducible in current environments: 2026-07-19 re-measurement
+        # gives 0.529024% (macOS/M3, bit-identical at the freeze commit and
+        # HEAD) and 0.636% (CI ubuntu) -- the metric is environment-sensitive
+        # because the residual is dominated by disperse_cube's bilinear
+        # sub-pixel shift interpolation, and the klpipe env was rebuilt near
+        # the freeze date. max_tol=0.010 set by user ruling 2026-07-20
+        # (~1.6x the worst measured platform, CI ubuntu 0.636%). The tight
+        # regression screws are mean_tol and flux_tol below, unchanged.
         kl_image, ref_image = _render_both(
             vcirc=200.0, n_lambda=None, dispersal_method='analytic'
         )
         _assert_agreement(
             kl_image,
             ref_image,
-            max_tol=0.006,
+            max_tol=0.010,
             mean_tol=0.0006,
             flux_tol=self.FLUX_TOL,
             label='dynamic scene (vcirc=200, analytic dispersal)',

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -1517,5 +1517,246 @@ class TestBinKwarg:
         assert result.shape == pdata.original_shape
 
 
+# ==============================================================================
+# F. rfft2 + minimal-exact-padding swap vs the prior full-pad fft2 reference
+# ==============================================================================
+#
+# The production PSF path (precompute_psf_fft + convolve_fft) uses a
+# half-spectrum rfft2 on the minimum FFT grid that is still exact on the
+# retained [0, N) crop (kernel placed by wrapped modulo-P folding). The
+# reference below reproduces the path as it stood before that swap: full
+# linear-convolution padding (next_fast_len(N + K - 1)), zero-pad + np.roll
+# kernel placement, full complex fft2 multiply ifft2, real-part crop. The two
+# differ only in FFT-grid size and factorization, so they must agree to the
+# float64 round-off floor on both value and gradient. This is the direct
+# old-vs-new numerical gate the swap ships against.
+
+
+def _render_psf_kernel(gsobj, pixel_scale, kernel_size=None):
+    """Render a normalized PSF kernel stamp (shared physics, both paths).
+
+    Reproduces the kernel-rendering half of ``gsobj_to_kernel``: GalSim good
+    image size, oddified, optional explicit override, ``drawImage`` at
+    ``pixel_scale``, normalized to unit sum. The convolution kernel is
+    therefore bit-identical between the reference and the production path;
+    only the padding/FFT machinery differs (which is what these tests probe).
+    """
+    kern_size = gsobj.getGoodImageSize(pixel_scale)
+    if kern_size % 2 == 0:
+        kern_size += 1
+    if kernel_size is not None:
+        kern_size = int(kernel_size)
+    kern_img = gsobj.drawImage(nx=kern_size, ny=kern_size, scale=pixel_scale)
+    kernel = kern_img.array.astype(np.float64)
+    kernel /= kernel.sum()
+    return kernel
+
+
+def _reference_full_pad_fft2_convolve(image, kernel, image_shape):
+    """Reference PSF convolution: full-pad, roll-placed, complex fft2 path.
+
+    The psf.py convolution as it stood before the rfft2 + minimal-exact
+    padding swap: pad to ``next_fast_len(N + K - 1)`` (full linear-convolution
+    size), place the kernel center at (0,0) by zero-pad + ``np.roll``, full
+    complex ``fft2`` multiply ``ifft2``, crop to ``[0, N)`` and take the real
+    part. Kept only as the numerical reference the production path validates
+    against; not used in production.
+    """
+    nrow, ncol = image_shape
+    krow, kcol = kernel.shape
+    nrow_pad = next_fast_len(nrow + krow - 1)
+    ncol_pad = next_fast_len(ncol + kcol - 1)
+    padded_kernel = np.zeros((nrow_pad, ncol_pad), dtype=np.float64)
+    padded_kernel[:krow, :kcol] = kernel
+    padded_kernel = np.roll(padded_kernel, (-(krow // 2), -(kcol // 2)), axis=(0, 1))
+    kernel_fft = jnp.fft.fft2(jnp.array(padded_kernel))
+
+    padded = jnp.zeros((nrow_pad, ncol_pad), dtype=image.dtype)
+    padded = padded.at[:nrow, :ncol].set(image)
+    result = jnp.fft.ifft2(jnp.fft.fft2(padded) * kernel_fft)
+    return result[:nrow, :ncol].real
+
+
+def _asymmetric_source(shape, pixel_scale):
+    """Off-center anisotropic blob: distinguishable under transpose.
+
+    Different x/y scale radii and different-sign offsets so a row/col swap
+    (the class of bug wrapped kernel placement or an rfft axis mix-up would
+    introduce) changes the array — a radially symmetric source would hide it.
+    """
+    ny, nx = shape
+    yy, xx = np.meshgrid(
+        (np.arange(ny) - ny / 2) * pixel_scale,
+        (np.arange(nx) - nx / 2) * pixel_scale,
+        indexing='ij',
+    )
+    r2 = ((xx - 0.4) / 1.2) ** 2 + ((yy + 0.2) / 0.7) ** 2
+    return np.exp(-np.sqrt(r2 + 1e-6)).astype(np.float64)
+
+
+# Old-vs-new agreement bound. Measured worst-case relative delta across the
+# parametrized cases (2026-07-19, this module): value 5.6e-16, gradient
+# 6.1e-16 — pure float64 round-off from the two paths' differing FFT grid
+# sizes and factorizations. Bound = 1e-14, the round-up of 10x that worst
+# case to the next decade, absorbing cross-platform FFT-planner round-off
+# variation. This is a floating-point-identity floor, NOT a physics
+# tolerance: the two paths compute the same linear map.
+_RFFT2_SWAP_RTOL = 1e-14
+
+_SWAP_KERNELS = [
+    pytest.param(gs.Gaussian(fwhm=0.7), 'gaussian_sym', id='gaussian_sym'),
+    pytest.param(
+        gs.Moffat(beta=3.5, fwhm=0.7).shear(g1=0.2, g2=0.25),
+        'moffat_sheared_asym',
+        id='moffat_sheared_asym',
+    ),
+]
+
+# even-even, odd-odd, even-odd, odd-even — exercises FFT-grid parity handling
+_SWAP_SHAPES = [(40, 40), (41, 41), (40, 41), (41, 40)]
+
+
+@pytest.mark.parametrize("gsobj,kname", _SWAP_KERNELS)
+@pytest.mark.parametrize("shape", _SWAP_SHAPES, ids=[str(s) for s in _SWAP_SHAPES])
+def test_rfft2_swap_matches_full_pad_reference_value_and_grad(gsobj, kname, shape):
+    """Production rfft2 + minimal-exact path == full-pad fft2 reference.
+
+    Direct old-vs-new comparison of BOTH the convolved value and the
+    gradient w.r.t. the input image, across a symmetric and an asymmetric
+    (transpose-distinguishable) kernel and all four shape parities. Also
+    confirms the production grid is strictly smaller than the full-pad grid
+    (the point of the swap).
+    """
+    pixel_scale = 0.3
+    image = jnp.array(_asymmetric_source(shape, pixel_scale))
+
+    psf_data = precompute_psf_fft(gsobj, image_shape=shape, pixel_scale=pixel_scale)
+    kernel = _render_psf_kernel(gsobj, pixel_scale)
+
+    # the swap must actually shrink the grid, else the comparison is vacuous
+    full_rows = next_fast_len(shape[0] + kernel.shape[0] - 1)
+    full_cols = next_fast_len(shape[1] + kernel.shape[1] - 1)
+    assert psf_data.padded_shape[0] < full_rows
+    assert psf_data.padded_shape[1] < full_cols
+
+    new = np.asarray(convolve_fft(image, psf_data))
+    ref = np.asarray(_reference_full_pad_fft2_convolve(image, kernel, shape))
+    value_rel = np.max(np.abs(new - ref)) / np.max(np.abs(ref))
+    assert (
+        value_rel < _RFFT2_SWAP_RTOL
+    ), f"{kname} {shape}: value_rel={value_rel:.3e} exceeds {_RFFT2_SWAP_RTOL:.0e}"
+
+    # asymmetric fixed weights so the scalar loss (and thus its gradient)
+    # depends on every output pixel, exercising the full adjoint of both paths
+    w = jnp.array(
+        np.outer(np.linspace(0.3, 1.7, shape[0]), np.linspace(0.5, 1.5, shape[1]))
+    )
+
+    def loss_new(im):
+        return jnp.sum(w * convolve_fft(im, psf_data))
+
+    def loss_ref(im):
+        return jnp.sum(w * _reference_full_pad_fft2_convolve(im, kernel, shape))
+
+    g_new = np.asarray(jax.grad(loss_new)(image))
+    g_ref = np.asarray(jax.grad(loss_ref)(image))
+    grad_rel = np.max(np.abs(g_new - g_ref)) / np.max(np.abs(g_ref))
+    assert (
+        grad_rel < _RFFT2_SWAP_RTOL
+    ), f"{kname} {shape}: grad_rel={grad_rel:.3e} exceeds {_RFFT2_SWAP_RTOL:.0e}"
+
+
+@pytest.mark.diagnostic_plots
+def test_rfft2_swap_diagnostic_plot(output_dir):
+    """Visual old-vs-new panel for the rfft2 + minimal-exact-padding swap.
+
+    Convolves an asymmetric source with an aberrated (Roman-like,
+    transpose-distinguishable) OpticalPSF via the production path and the
+    full-pad fft2 reference, then plots old / new / log-scale residual and
+    prints the max abs/rel value and gradient differences. Figure + CSV land
+    in tests/out/psf_rfft2_swap/ for inspection. Deltas are the float64
+    round-off floor; this figure exists to make that visible, not to gate.
+    """
+    out_dir = get_test_dir() / "out" / "psf_rfft2_swap"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    pixel_scale = 0.3
+    shape = (60, 64)
+    gsobj = gs.OpticalPSF(
+        lam_over_diam=0.5, defocus=0.4, coma1=0.3, coma2=0.2, astig1=0.15
+    )
+    image = jnp.array(_asymmetric_source(shape, pixel_scale))
+
+    psf_data = precompute_psf_fft(gsobj, image_shape=shape, pixel_scale=pixel_scale)
+    kernel = _render_psf_kernel(gsobj, pixel_scale)
+
+    new = np.asarray(convolve_fft(image, psf_data))
+    ref = np.asarray(_reference_full_pad_fft2_convolve(image, kernel, shape))
+    residual = new - ref
+    value_maxabs = float(np.max(np.abs(residual)))
+    value_maxrel = float(value_maxabs / np.max(np.abs(ref)))
+
+    w = jnp.array(
+        np.outer(np.linspace(0.3, 1.7, shape[0]), np.linspace(0.5, 1.5, shape[1]))
+    )
+
+    def loss_new(im):
+        return jnp.sum(w * convolve_fft(im, psf_data))
+
+    def loss_ref(im):
+        return jnp.sum(w * _reference_full_pad_fft2_convolve(im, kernel, shape))
+
+    g_new = np.asarray(jax.grad(loss_new)(image))
+    g_ref = np.asarray(jax.grad(loss_ref)(image))
+    grad_maxabs = float(np.max(np.abs(g_new - g_ref)))
+    grad_maxrel = float(grad_maxabs / np.max(np.abs(g_ref)))
+
+    full_rows = next_fast_len(shape[0] + kernel.shape[0] - 1)
+
+    print(
+        f"\n[rfft2 swap] shape={shape} "
+        f"pad_new={tuple(psf_data.padded_shape)} pad_full~=({full_rows},{full_rows})"
+    )
+    print(f"[rfft2 swap] value: max|diff|={value_maxabs:.3e} rel={value_maxrel:.3e}")
+    print(f"[rfft2 swap] grad : max|diff|={grad_maxabs:.3e} rel={grad_maxrel:.3e}")
+
+    csv_path = out_dir / "rfft2_swap_deltas.csv"
+    csv_path.write_text(
+        "quantity,max_abs_diff,max_rel_diff\n"
+        f"value,{value_maxabs:.6e},{value_maxrel:.6e}\n"
+        f"gradient,{grad_maxabs:.6e},{grad_maxrel:.6e}\n"
+    )
+
+    fig, axes = plt.subplots(1, 3, figsize=(15, 4.5))
+    vmax = float(np.max(np.abs(ref)))
+    im0 = axes[0].imshow(ref, origin='lower', vmin=0, vmax=vmax)
+    axes[0].set_title('old: full-pad fft2 reference')
+    fig.colorbar(im0, ax=axes[0], fraction=0.046)
+    im1 = axes[1].imshow(new, origin='lower', vmin=0, vmax=vmax)
+    axes[1].set_title('new: rfft2 + minimal-exact pad')
+    fig.colorbar(im1, ax=axes[1], fraction=0.046)
+
+    absres = np.abs(residual)
+    floor = max(absres[absres > 0].min(), 1e-300) if np.any(absres > 0) else 1e-300
+    im2 = axes[2].imshow(
+        np.where(absres > 0, absres, floor),
+        origin='lower',
+        norm=LogNorm(vmin=floor, vmax=max(value_maxabs, floor * 10)),
+        cmap='magma',
+    )
+    axes[2].set_title(
+        f'|new - old| (log)\nmax rel: value {value_maxrel:.1e}, grad {grad_maxrel:.1e}'
+    )
+    fig.colorbar(im2, ax=axes[2], fraction=0.046)
+    fig.suptitle('PSF rfft2 + minimal-exact-padding swap: old vs new (OpticalPSF)')
+    fig.tight_layout()
+    fig.savefig(out_dir / 'rfft2_swap_panel.png', dpi=150)
+    plt.close(fig)
+
+    # sanity: the figure only exists because the deltas are at round-off
+    assert value_maxrel < _RFFT2_SWAP_RTOL
+    assert grad_maxrel < _RFFT2_SWAP_RTOL
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])

--- a/tests/test_render_config.py
+++ b/tests/test_render_config.py
@@ -457,6 +457,10 @@ class TestEffectiveMaxkLoudGuard:
 
         class _DeadPSF:
             # FT well below threshold at every k, including k=0 (not normalized)
+            maxk = (
+                100.0  # band limit above the scan range; real GSObjects always have one
+            )
+
             def kValue(self, pos):
                 return 1e-9 + 0j
 

--- a/tests/test_roman_psf.py
+++ b/tests/test_roman_psf.py
@@ -82,7 +82,12 @@ class TestRomanPSFConfig:
             assert config.band_psf[band].psf_type == 'roman_wfi'
             assert config.band_psf[band].sca == 10
             assert config.band_psf[band].pupil_bin == 4
+            # fit kernels loosened to 0.01 (gated); mock kernels at default
+            assert config.band_psf[band].folding_threshold == 0.01
+            assert config.band_psf[band].mock_folding_threshold is None
         assert config.grism_psf.psf_type == 'roman_wfi'
+        assert config.grism_psf.folding_threshold == 0.01
+        assert config.grism_psf.mock_folding_threshold is None
 
     def test_roman_defaults_applied(self, tmp_path):
         d = _config_dict()
@@ -186,6 +191,68 @@ class TestRomanPSFConfig:
         for ft in (0.0, 1.0, -0.01):
             with pytest.raises(ValueError, match='folding_threshold'):
                 PSFSpec(psf_type='roman_wfi', sca=10, pupil_bin=4, folding_threshold=ft)
+
+    def test_mock_folding_threshold_rules(self, tmp_path):
+        # mock (truth-render) kernels must be at least as accurate as fit
+        # kernels; None means the galsim default 5e-3
+        with pytest.raises(ValueError, match='at least as accurate'):
+            PSFSpec(
+                psf_type='roman_wfi', sca=10, pupil_bin=4, mock_folding_threshold=0.02
+            )
+        with pytest.raises(ValueError, match='at least as accurate'):
+            PSFSpec(
+                psf_type='roman_wfi',
+                sca=10,
+                pupil_bin=4,
+                folding_threshold=0.01,
+                mock_folding_threshold=0.02,
+            )
+        with pytest.raises(ValueError, match='roman_wfi-only'):
+            PSFSpec(psf_type='gaussian', fwhm_arcsec=0.18, mock_folding_threshold=0.005)
+        # equal and tighter-than-fit are both allowed
+        PSFSpec(
+            psf_type='roman_wfi',
+            sca=10,
+            pupil_bin=4,
+            folding_threshold=0.01,
+            mock_folding_threshold=0.01,
+        )
+        spec = PSFSpec(
+            psf_type='roman_wfi',
+            sca=10,
+            pupil_bin=4,
+            folding_threshold=0.01,
+            mock_folding_threshold=0.001,
+        )
+        assert spec.mock_folding_threshold == 0.001
+        # YAML parsing round-trip
+        d = _config_dict()
+        d['psf']['grism'] = {
+            'type': 'roman_wfi',
+            'folding_threshold': 0.01,
+            'mock_folding_threshold': 0.005,
+        }
+        config = ObservingConfig.from_yaml(_write_config(tmp_path, d))
+        assert config.grism_psf.mock_folding_threshold == 0.005
+
+    def test_dual_fidelity_kernel_split(self):
+        # a spec with a loosened fit threshold builds DIFFERENT mock vs fit
+        # PSF objects (cache keys differ); an unsplit spec shares one object
+        split = PSFSpec(
+            psf_type='roman_wfi', sca=10, pupil_bin=4, folding_threshold=0.01
+        )
+        assert _build_grism_psf(split, 1.2, mock=True) is not _build_grism_psf(
+            split, 1.2
+        )
+        unsplit = PSFSpec(psf_type='roman_wfi', sca=10, pupil_bin=4)
+        assert _build_grism_psf(unsplit, 1.2, mock=True) is _build_grism_psf(
+            unsplit, 1.2
+        )
+        # mock kernels are the larger (more accurate) ones
+        fine_ps = PIXEL_SCALE / 3
+        assert _build_grism_psf(split, 1.2, mock=True).getGoodImageSize(
+            fine_ps
+        ) > _build_grism_psf(split, 1.2).getGoodImageSize(fine_ps)
 
 
 # ==============================================================================
@@ -641,6 +708,56 @@ def test_folding_threshold_render_fidelity(tmp_path):
     assert np.max(np.abs(diff)) / np.max(grism_ref) < 4e-3
     assert np.sqrt(np.sum(diff**2)) / sigma < 6.0
     np.testing.assert_array_equal(band_ft, band_ref)
+
+
+@pytest.mark.slow
+def test_dual_fidelity_data_uses_mock_kernel(tmp_path):
+    """build_fit_inputs renders the mock DATA through the mock-fidelity
+    kernel while the fit obs carries the loosened fit kernel: a split config
+    (fit ft=0.01, mock default) and a matched config (both 0.01) with the
+    same noise seed must produce different grism data but identical fit-obs
+    kernel shapes."""
+
+    def _inputs(mock_ft):
+        d = _config_dict()
+        d['id'] = f'dual_fid_{mock_ft}'
+        d['bands'] = ['F158']
+        d['psf'] = {
+            'broadband': {'type': 'roman_wfi', 'folding_threshold': 0.01},
+            'grism': {'type': 'roman_wfi', 'folding_threshold': 0.01},
+        }
+        if mock_ft is not None:
+            d['psf']['grism']['mock_folding_threshold'] = mock_ft
+            d['psf']['broadband']['mock_folding_threshold'] = mock_ft
+        d['render'] = {'oversample': 3}
+        config = ObservingConfig.from_yaml(_write_config(tmp_path, d))
+        spec = EnsembleSpec.from_yaml(DEV_SPEC)
+        truth = scene_truth_defaults(config, spec.fixed)
+        truth.update(
+            {
+                'cosi': 0.5,
+                'theta_int': 0.6,
+                'g1': 0.02,
+                'g2': -0.01,
+                'vel.vcirc': 200.0,
+                'z': 1.2,
+            }
+        )
+        return build_fit_inputs(
+            truth, 11, spec, config, broadband_snr=100.0, line_snr=100.0
+        )
+
+    split = _inputs(None)  # mock at galsim default, fit at 0.01
+    matched = _inputs(0.01)  # both at 0.01
+
+    roll_split = split.grism_obs['roll0']
+    roll_matched = matched.grism_obs['roll0']
+    # same fit-kernel shapes either way
+    assert roll_split.psf_data.padded_shape == roll_matched.psf_data.padded_shape
+    # but the data was rendered through different (mock) kernels
+    assert not np.array_equal(
+        np.asarray(roll_split.data), np.asarray(roll_matched.data)
+    )
 
 
 @pytest.mark.slow

--- a/tests/test_roman_psf.py
+++ b/tests/test_roman_psf.py
@@ -76,7 +76,7 @@ def _pinned_kernel_size(pixel_scale: float, z_max: float = Z_HI) -> int:
 class TestRomanPSFConfig:
     def test_registry_roman_config_loads(self):
         config = ObservingConfig.from_yaml(REGISTRY / 'canonical_P_roman.yaml')
-        assert config.bands == ('H158', 'F184')
+        assert config.bands == ('F158', 'F184')
         assert config.grism_rolls_deg == (0.0, 45.0, 90.0, 135.0)
         for band in config.bands:
             assert config.band_psf[band].psf_type == 'roman_wfi'
@@ -106,20 +106,16 @@ class TestRomanPSFConfig:
         d['psf']['grism'] = {'type': 'roman_wfi'}
         config = ObservingConfig.from_yaml(_write_config(tmp_path, d))
         assert config.band_psf['F087'].psf_type == 'gaussian'
-        assert config.band_psf_fwhm == {'F087': 0.18}
+        assert config.band_psf['F087'].fwhm_arcsec == 0.18
         assert config.grism_psf.psf_type == 'roman_wfi'
 
     def test_gaussian_configs_unchanged(self):
         config = ObservingConfig.from_yaml(REGISTRY / 'canonical_P.yaml')
-        assert config.band_psf_fwhm == {'F087': 0.18, 'F158': 0.18}
-        assert config.grism_psf_fwhm == 0.18
-
-    def test_fwhm_properties_raise_for_roman(self):
-        config = ObservingConfig.from_yaml(REGISTRY / 'canonical_P_roman.yaml')
-        with pytest.raises(ValueError, match='gaussian PSFs only'):
-            config.band_psf_fwhm
-        with pytest.raises(ValueError, match='gaussian PSFs only'):
-            config.grism_psf_fwhm
+        assert {b: p.fwhm_arcsec for b, p in config.band_psf.items()} == {
+            'F087': 0.18,
+            'F158': 0.18,
+        }
+        assert config.grism_psf.fwhm_arcsec == 0.18
 
     def test_unknown_type_raises(self, tmp_path):
         for channel in ('broadband', 'grism'):
@@ -165,6 +161,32 @@ class TestRomanPSFConfig:
         with pytest.raises(NotImplementedError, match='not supported'):
             PSFSpec(psf_type='airy')
 
+    def test_folding_threshold_parsing(self, tmp_path):
+        d = _config_dict()
+        d['psf']['grism'] = {'type': 'roman_wfi', 'folding_threshold': 0.02}
+        config = ObservingConfig.from_yaml(_write_config(tmp_path, d))
+        assert config.grism_psf.folding_threshold == 0.02
+        d['psf']['grism'] = {'type': 'roman_wfi'}
+        config = ObservingConfig.from_yaml(_write_config(tmp_path, d))
+        assert config.grism_psf.folding_threshold is None  # galsim default
+
+    def test_folding_threshold_roman_only(self, tmp_path):
+        d = _config_dict()
+        d['psf']['grism'] = {
+            'type': 'gaussian',
+            'fwhm_arcsec': 0.18,
+            'folding_threshold': 0.02,
+        }
+        with pytest.raises(ValueError, match='unknown keys'):
+            ObservingConfig.from_yaml(_write_config(tmp_path, d))
+        with pytest.raises(ValueError, match='roman_wfi-only'):
+            PSFSpec(psf_type='gaussian', fwhm_arcsec=0.18, folding_threshold=0.02)
+
+    def test_folding_threshold_bad_value_raises(self):
+        for ft in (0.0, 1.0, -0.01):
+            with pytest.raises(ValueError, match='folding_threshold'):
+                PSFSpec(psf_type='roman_wfi', sca=10, pupil_bin=4, folding_threshold=ft)
+
 
 # ==============================================================================
 # Kernel construction (monochromatic getPSF)
@@ -182,17 +204,25 @@ class TestRomanKernel:
         assert _build_grism_psf(ROMAN_SPEC, Z_HI) is _build_grism_psf(ROMAN_SPEC, Z_HI)
 
     def test_band_effective_wavelengths(self):
-        # galsim.roman effective wavelengths are in nm; H158/F184 pivots
+        # galsim.roman effective wavelengths are in nm; F158/F184 pivots
         # are ~1.58/1.84 um, a loose bracket guards a silent unit change
-        lam_h158 = _band_effective_wavelength_nm('H158')
+        lam_f158 = _band_effective_wavelength_nm('F158')
         lam_f184 = _band_effective_wavelength_nm('F184')
-        assert 1500.0 < lam_h158 < 1650.0
+        assert 1500.0 < lam_f158 < 1650.0
         assert 1750.0 < lam_f184 < 1900.0
 
+    def test_official_and_galsim_band_names_agree(self):
+        # official Roman filter names map onto galsim's legacy WFIRST keys
+        assert _band_effective_wavelength_nm('F158') == (
+            _band_effective_wavelength_nm('H158')
+        )
+        assert _band_effective_wavelength_nm('F087') == (
+            _band_effective_wavelength_nm('Z087')
+        )
+
     def test_non_roman_band_raises(self):
-        # flagship band names (F087/F158) are not Roman WFI bandpasses
-        with pytest.raises(ValueError, match='not a Roman WFI bandpass'):
-            _build_band_psf(ROMAN_SPEC, 'F087')
+        with pytest.raises(ValueError, match='not a Roman WFI filter'):
+            _build_band_psf(ROMAN_SPEC, 'F999')
 
     def test_kernel_unit_normalized_and_finite(self):
         psf = _build_grism_psf(ROMAN_SPEC, 1.2)
@@ -292,7 +322,7 @@ class TestRomanObs:
 
     def test_image_obs_with_roman_psf(self):
         image_pars = ImagePars(shape=(32, 32), pixel_scale=PIXEL_SCALE, indexing='ij')
-        psf = _build_band_psf(ROMAN_SPEC, 'H158')
+        psf = _build_band_psf(ROMAN_SPEC, 'F158')
         obs = build_image_obs(
             image_pars, psf=psf, render_config=RenderConfig(oversample=1)
         )
@@ -366,17 +396,167 @@ class TestRomanObs:
             _build_grism_psf(ROMAN_SPEC, 1.0 + 0.01 * i)
         assert len(mocks_mod._ROMAN_PSF_CACHE) <= mocks_mod._ROMAN_PSF_CACHE_MAX
 
+    def test_folding_threshold_shrinks_pinned_kernel(self):
+        # a looser folding threshold trades far-wing truncation for a much
+        # smaller kernel stamp (and padded convolution FFT); measured at
+        # z=1.9, fine scale 0.11/3: 992 -> 252 px with 99.93% of flux still
+        # inside the stamp
+        loose = PSFSpec(
+            psf_type='roman_wfi', sca=10, pupil_bin=4, folding_threshold=0.02
+        )
+        fine_ps = PIXEL_SCALE / 3
+        size_default = _build_grism_psf(ROMAN_SPEC, Z_HI).getGoodImageSize(fine_ps)
+        size_loose = _build_grism_psf(loose, Z_HI).getGoodImageSize(fine_ps)
+        assert size_loose < size_default / 2
+        # distinct cache entries: threshold is part of the key
+        assert _build_grism_psf(loose, Z_HI) is not _build_grism_psf(ROMAN_SPEC, Z_HI)
+
+    def test_effective_maxk_ignores_kvalue_sidelobes(self):
+        # regression: the interpolated-pupil roman PSF's kValue bounces back
+        # above the 1e-3 threshold beyond its physical band limit (psf.maxk:
+        # the measured optical FT is ~5e-7 at the aperture cutoff but ~2e-2
+        # at k=70). The grism scan must not follow those sidelobes, else the
+        # priors-implied oversample explodes (7 vs the config's 3) and every
+        # production roman fit raises in InferenceTask.from_obs.
+        from kl_pipe.intensity import build_intensity_model
+        from kl_pipe.render import compute_effective_maxk_grism
+
+        psf = _build_grism_psf(ROMAN_SPEC, 1.2)
+        model = build_intensity_model('default')
+        params = {
+            'flux': 1.0,
+            'rscale': 0.35,
+            'cosi': 0.5,
+            'h_over_r': 0.1,
+            'theta_int': 0.0,
+            'g1': 0.0,
+            'g2': 0.0,
+            'x0': 0.0,
+            'y0': 0.0,
+        }
+        # grad_v_max/sigma_v chosen so the bare cube bandwidth (~370
+        # rad/arcsec) is far beyond the PSF band limit (~49): the scan
+        # result must be capped by the PSF, not the sidelobes
+        maxk = compute_effective_maxk_grism(
+            model, params, sigma_v=20.0, grad_v_max=2000.0, psf=psf
+        )
+        assert maxk <= float(psf.maxk) + 1e-9
+
+
+@pytest.mark.slow
+def test_folding_threshold_render_fidelity(tmp_path):
+    """Render distortion from a loosened kernel folding threshold, against
+    the default-threshold reference on the same scene. Bounds are 10x the
+    measured distortion (2026-07-18, canonical_P_roman geometry, z=1.2,
+    kernel pinned at z=1.9, line SNR 100): grism max|d|/peak = 3.3e-4 ->
+    4e-3; whole-stamp chi at SNR 100 = 0.51 -> 6.0. The knob does not touch
+    the broadband path (its kernel FT is evaluated analytically in k-space,
+    independent of the drawn stamp), pinned here by exact equality."""
+
+    def _clean_renders(ft):
+        d = _config_dict()
+        d['id'] = f'roman_fidelity_{ft}'
+        d['bands'] = ['F158']
+        d['psf'] = {
+            'broadband': {'type': 'roman_wfi'},
+            'grism': {'type': 'roman_wfi'},
+        }
+        if ft is not None:
+            d['psf']['broadband']['folding_threshold'] = ft
+            d['psf']['grism']['folding_threshold'] = ft
+        d['render'] = {'oversample': 3}
+        config = ObservingConfig.from_yaml(_write_config(tmp_path, d))
+        spec = EnsembleSpec.from_yaml(DEV_SPEC)
+        truth = scene_truth_defaults(config, spec.fixed)
+        truth.update(
+            {
+                'cosi': 0.5,
+                'theta_int': 0.6,
+                'g1': 0.02,
+                'g2': -0.01,
+                'vel.vcirc': 200.0,
+                'z': 1.2,
+            }
+        )
+        inputs = build_fit_inputs(
+            truth, 11, spec, config, broadband_snr=100.0, line_snr=100.0
+        )
+        grism = np.asarray(inputs.source.render_grism(truth, inputs.grism_obs['roll0']))
+        band = np.asarray(
+            inputs.source.render_broadband(truth, inputs.image_obs['F158'], 'F158')
+        )
+        sigma = float(np.sqrt(float(np.asarray(inputs.grism_obs['roll0'].variance))))
+        return grism, band, sigma
+
+    grism_ref, band_ref, sigma = _clean_renders(None)
+    grism_ft, band_ft, _ = _clean_renders(0.02)
+
+    diff = grism_ft - grism_ref
+    assert np.max(np.abs(diff)) / np.max(grism_ref) < 4e-3
+    assert np.sqrt(np.sum(diff**2)) / sigma < 6.0
+    np.testing.assert_array_equal(band_ft, band_ref)
+
+
+@pytest.mark.slow
+def test_from_obs_roman_production_path(tmp_path):
+    """The worker's exact fit-construction path with roman PSFs on both
+    channels: build_fit_inputs at the config oversample, then
+    InferenceTask.from_obs, then one finite log-posterior + gradient.
+    Regression: the priors-implied render config once demanded oversample 7
+    (kValue sidelobes beyond the PSF band limit) and from_obs raised on
+    every production roman fit."""
+    import jax
+
+    from kl_pipe.sampling import InferenceTask
+
+    spec = EnsembleSpec.from_yaml(DEV_SPEC)
+    d = _config_dict()
+    d['id'] = 'roman_prod_path'
+    d['bands'] = ['F158']
+    d['psf'] = {
+        'broadband': {'type': 'roman_wfi'},
+        'grism': {'type': 'roman_wfi'},
+    }
+    d['render'] = {'oversample': 3}
+    config = ObservingConfig.from_yaml(_write_config(tmp_path, d))
+
+    truth = scene_truth_defaults(config, spec.fixed)
+    truth.update(
+        {
+            'cosi': 0.5,
+            'theta_int': 0.6,
+            'g1': 0.02,
+            'g2': -0.01,
+            'vel.vcirc': 200.0,
+            'z': 1.2,
+        }
+    )
+    inputs = build_fit_inputs(
+        truth, 11, spec, config, broadband_snr=100.0, line_snr=100.0
+    )
+    task = InferenceTask.from_obs(
+        inputs.source,
+        inputs.priors,
+        image_obs=inputs.image_obs,
+        grism_obs=inputs.grism_obs,
+    )
+    fn = task.get_log_posterior_and_grad_fn()
+    theta0 = task.sample_prior(jax.random.PRNGKey(0), 1)[0]
+    val, grad = fn(theta0)
+    assert np.isfinite(float(val))
+    assert np.all(np.isfinite(np.asarray(grad)))
+
 
 @pytest.mark.slow
 def test_build_fit_inputs_roman_smoke(tmp_path):
     """End-to-end mock construction with roman_wfi PSFs on both channels:
-    one H158 band + one grism roll, oversample 1 to keep the kernel grids
+    one F158 band + one grism roll, oversample 1 to keep the kernel grids
     small. Asserts valid PSFData on every obs, finite noisy data, and a
     finite truth render through the fit's own obs."""
     spec = EnsembleSpec.from_yaml(DEV_SPEC)
     d = _config_dict()
     d['id'] = 'roman_smoke'
-    d['bands'] = ['H158']
+    d['bands'] = ['F158']
     d['psf'] = {
         'broadband': {'type': 'roman_wfi'},
         'grism': {'type': 'roman_wfi'},
@@ -399,7 +579,7 @@ def test_build_fit_inputs_roman_smoke(tmp_path):
         truth, 11, spec, config, broadband_snr=100.0, line_snr=100.0
     )
 
-    assert set(inputs.image_obs) == {'H158'}
+    assert set(inputs.image_obs) == {'F158'}
     assert set(inputs.grism_obs) == {'roll0'}
     for obs in list(inputs.image_obs.values()) + list(inputs.grism_obs.values()):
         assert obs.psf_data is not None
@@ -407,7 +587,7 @@ def test_build_fit_inputs_roman_smoke(tmp_path):
         assert float(np.asarray(obs.variance)) > 0
 
     band_render = np.asarray(
-        inputs.source.render_broadband(truth, inputs.image_obs['H158'], 'H158')
+        inputs.source.render_broadband(truth, inputs.image_obs['F158'], 'F158')
     )
     grism_render = np.asarray(
         inputs.source.render_grism(truth, inputs.grism_obs['roll0'])

--- a/tests/test_roman_psf.py
+++ b/tests/test_roman_psf.py
@@ -39,7 +39,10 @@ DEV_SPEC = REPO_ROOT / 'configs' / 'ensembles' / 'sigma_eps_cosi_dev.yaml'
 # canonical geometry (matches the observing-config registry)
 PIXEL_SCALE = 0.11  # arcsec/pix
 
-# ensemble z range endpoints (specs draw z uniform on [1.0, 1.9])
+# wavelength-scaling test endpoints: Z_HI matches the current spec z-draw
+# upper bound (uniform on [1.0, 1.9], the pinning reference); Z_LO = 0.55 is
+# the planned ensemble lower bound (Halpha enters G150 at z~0.52), used here
+# as a low-z reference to exercise the full kernel-size spread
 Z_LO = 0.55
 Z_HI = 1.9
 
@@ -143,6 +146,14 @@ class TestRomanPSFConfig:
         d['psf']['grism'] = {'type': 'roman_wfi', 'pupil_bin': 0}
         with pytest.raises(ValueError, match='pupil_bin'):
             ObservingConfig.from_yaml(_write_config(tmp_path, d))
+
+    def test_non_integer_sca_pupil_bin_rejected(self, tmp_path):
+        # YAML floats/strings must raise, not silently truncate via int()
+        for key, val in (('sca', 10.9), ('sca', '10'), ('pupil_bin', 4.5)):
+            d = _config_dict()
+            d['psf']['grism'] = {'type': 'roman_wfi', key: val}
+            with pytest.raises(ValueError, match='must be an integer'):
+                ObservingConfig.from_yaml(_write_config(tmp_path, d))
 
     def test_psfspec_cross_field_validation(self):
         with pytest.raises(ValueError, match='roman_wfi-only'):
@@ -311,6 +322,49 @@ class TestRomanObs:
             )
             shapes[z] = (obs.psf_data.padded_shape, obs.psf_data.kernel_fft.shape)
         assert shapes[Z_LO] == shapes[Z_HI]
+
+    def test_with_render_config_preserves_pinned_kernel(self):
+        # regression: InferenceTask.from_obs rebuilds explicit-rc grism obs via
+        # with_render_config to fill line_window_halfwidth on the analytic
+        # path; the rebuild must keep the pinned kernel size, else shapes
+        # vary with z again
+        import dataclasses
+
+        from kl_pipe.dispersion import build_grism_pars_for_line
+
+        pin = _pinned_kernel_size(PIXEL_SCALE)
+        z = Z_LO  # far from the pinning reference so auto size != pin
+        grism_pars = build_grism_pars_for_line(
+            LINE_LAMBDAS['Halpha'],
+            redshift=z,
+            image_pars=ImagePars(
+                shape=(32, 32), pixel_scale=PIXEL_SCALE, indexing='ij'
+            ),
+            dispersion=1.1,
+        )
+        rc = RenderConfig(oversample=1)
+        obs = build_grism_obs(
+            grism_pars,
+            z=z,
+            psf=_build_grism_psf(ROMAN_SPEC, z),
+            render_config=rc,
+            psf_kernel_size=pin,
+        )
+        rebuilt = obs.with_render_config(
+            dataclasses.replace(rc, line_window_halfwidth=3)
+        )
+        assert rebuilt.psf_kernel_size == pin
+        assert rebuilt.psf_data.padded_shape == obs.psf_data.padded_shape
+        assert rebuilt.psf_data.kernel_fft.shape == obs.psf_data.kernel_fft.shape
+
+    def test_roman_psf_cache_bounded(self):
+        from kl_pipe.ensemble import mocks as mocks_mod
+
+        mocks_mod._ROMAN_PSF_CACHE.clear()
+        n = mocks_mod._ROMAN_PSF_CACHE_MAX + 5
+        for i in range(n):
+            _build_grism_psf(ROMAN_SPEC, 1.0 + 0.01 * i)
+        assert len(mocks_mod._ROMAN_PSF_CACHE) <= mocks_mod._ROMAN_PSF_CACHE_MAX
 
 
 @pytest.mark.slow

--- a/tests/test_roman_psf.py
+++ b/tests/test_roman_psf.py
@@ -370,6 +370,180 @@ class TestRomanKernel:
 
 
 # ==============================================================================
+# Kernel conventions: orientation, parity, centering, normalization, pixel
+# contract -- with the real (asymmetric) roman kernel. Round-PSF tests are
+# blind to a transpose/flip bug; the roman diffraction spikes are not.
+# ==============================================================================
+
+
+class TestRomanKernelConventions:
+    """Both PSF pathways against GalSim references on an asymmetric kernel.
+
+    Bounds provenance (measured 2026-07-18, SCA 10, pupil_bin 4, H158
+    effective wavelength, 32 px stamp at 0.11 arcsec, oversample 3, sheared
+    inclined-exponential scene rscale=0.35, g=(0.05,-0.03), offset
+    (0.11,-0.055)):
+    - k-space fused path vs galsim native: max|d|/peak = 7.0e-4; bound 2e-3
+      (~3x measured) chosen deliberately BELOW the measured residual of a
+      transposed kernel (8.0e-3) so a parity bug cannot pass; the transpose
+      control asserts that failure mode stays detectable.
+    - delta-image patch identity (real-space kernel path): 7.1e-8 (FFT
+      roundoff); bound 1e-6 (~10x). Flipped/transposed comparisons measured
+      6.6e-2 / 2.5e-2; controls assert > 1e-2.
+    - real-space path end-to-end vs galsim: 2.7e-3 (dominated by the
+      point-sampled-SB quadrature at oversample 3, not orientation);
+      bound 3e-2 (10x, rounded up).
+    """
+
+    def _scene(self):
+        return dict(
+            cosi=0.6,
+            theta_int=np.pi / 4,
+            g1=0.05,
+            g2=-0.03,
+            flux=1.0,
+            rscale=0.35,
+            h_over_r=0.1,
+            x0=0.11,
+            y0=-0.055,
+        )
+
+    def _psf(self):
+        return _build_band_psf(ROMAN_SPEC, 'F158')
+
+    def test_kspace_path_matches_galsim_and_catches_transpose(self):
+        import dataclasses
+
+        import jax.numpy as jnp
+
+        from kl_pipe.intensity import InclinedExponentialModel
+        from kl_pipe.synthetic import _generate_sersic_galsim
+
+        pars = self._scene()
+        psf = self._psf()
+        image_pars = ImagePars(shape=(32, 32), pixel_scale=PIXEL_SCALE, indexing='ij')
+        model = InclinedExponentialModel()
+        obs = build_image_obs(
+            image_pars,
+            psf=psf,
+            render_config=RenderConfig(oversample=3),
+            int_model=model,
+        )
+        theta = jnp.array(
+            [
+                pars['cosi'],
+                pars['theta_int'],
+                pars['g1'],
+                pars['g2'],
+                pars['flux'],
+                pars['rscale'],
+                pars['h_over_r'],
+                pars['x0'],
+                pars['y0'],
+            ]
+        )
+        ours = np.array(model.render_image(theta, obs=obs))
+        ref = _generate_sersic_galsim(
+            image_pars,
+            flux=pars['flux'],
+            rscale=pars['rscale'],
+            n_sersic=1.0,
+            cosi=pars['cosi'],
+            theta_int=pars['theta_int'],
+            g1=pars['g1'],
+            g2=pars['g2'],
+            x0=pars['x0'],
+            y0=pars['y0'],
+            h_over_r=pars['h_over_r'],
+            psf=psf,
+            method='auto',
+        )
+        peak = np.max(np.abs(ref))
+        assert np.max(np.abs(ours - ref)) / peak < 2e-3
+
+        # parity control: a transposed fused kernel must fail the same bound,
+        # proving the comparison is sensitive to an orientation bug
+        obs_t = dataclasses.replace(obs, kspace_psf_fft=obs.kspace_psf_fft.T)
+        ours_t = np.array(model.render_image(theta, obs=obs_t))
+        assert np.max(np.abs(ours_t - ref)) / peak > 2e-3
+
+    def test_realspace_kernel_delta_identity_and_parity(self):
+        import jax.numpy as jnp
+
+        from kl_pipe.psf import convolve_fft
+
+        psf = self._psf()
+        oversample = 3
+        fine_ps = PIXEL_SCALE / oversample
+        psf_data = precompute_psf_fft(
+            psf, image_shape=(32, 32), pixel_scale=PIXEL_SCALE, oversample=oversample
+        )
+        fine_n = 32 * oversample
+        delta = np.zeros((fine_n, fine_n))
+        r0, c0 = fine_n // 2 + 7, fine_n // 2 - 5
+        delta[r0, c0] = 1.0
+        conv = np.array(convolve_fft(jnp.asarray(delta), psf_data, bin=False))
+
+        kern_size = psf.getGoodImageSize(fine_ps)
+        if kern_size % 2 == 0:
+            kern_size += 1
+        kimg = psf.drawImage(nx=kern_size, ny=kern_size, scale=fine_ps).array
+        kimg = kimg / kimg.sum()
+        h = 20
+        kc = kern_size // 2
+        patch = conv[r0 - h : r0 + h + 1, c0 - h : c0 + h + 1]
+        kpatch = kimg[kc - h : kc + h + 1, kc - h : kc + h + 1]
+        kpeak = np.max(kpatch)
+
+        # a delta convolved with the kernel must reproduce the drawn kernel
+        # stamp at the delta position: validates centering (no half-pixel
+        # offset from the pad+roll) and array orientation of the FFT path
+        assert np.max(np.abs(patch - kpatch)) / kpeak < 1e-6
+        # parity controls: flipped or transposed stamps must NOT match
+        assert np.max(np.abs(patch - kpatch[::-1, ::-1])) / kpeak > 1e-2
+        assert np.max(np.abs(patch - kpatch.T)) / kpeak > 1e-2
+
+    def test_realspace_path_matches_galsim(self):
+        import galsim as gs
+        import jax.numpy as jnp
+
+        from kl_pipe.psf import convolve_fft
+
+        pars = self._scene()
+        psf = self._psf()
+        oversample = 3
+        fine_ps = PIXEL_SCALE / oversample
+        fine_n = 32 * oversample
+        psf_data = precompute_psf_fft(
+            psf, image_shape=(32, 32), pixel_scale=PIXEL_SCALE, oversample=oversample
+        )
+        gal = (
+            gs.InclinedExponential(
+                inclination=np.arccos(pars['cosi']) * gs.radians,
+                scale_radius=pars['rscale'],
+                scale_h_over_r=pars['h_over_r'],
+                flux=pars['flux'],
+            )
+            .rotate(pars['theta_int'] * gs.radians)
+            .shear(g1=pars['g1'], g2=pars['g2'])
+            .shift(pars['x0'], pars['y0'])
+        )
+        # point-sampled SB through our kernel: the drawImage kernel's own
+        # fine-pixel factor is the quadrature weight that turns the discrete
+        # convolution into the continuous one (NOT a pixel double-count; the
+        # detector coarse pixel is applied exactly once, downstream)
+        sb = gal.drawImage(nx=fine_n, ny=fine_n, scale=fine_ps, method='sb').array
+        conv_sb = np.array(convolve_fft(jnp.asarray(sb), psf_data, bin=False))
+        ref = (
+            gs.Convolve(gal, psf)
+            .drawImage(nx=fine_n, ny=fine_n, scale=fine_ps, method='auto')
+            .array
+            / fine_ps**2
+        )
+        assert np.max(np.abs(conv_sb - ref)) / np.max(np.abs(ref)) < 3e-2
+
+
+# ==============================================================================
 # Obs construction
 # ==============================================================================
 

--- a/tests/test_roman_psf.py
+++ b/tests/test_roman_psf.py
@@ -1,0 +1,364 @@
+"""
+Tests for the roman_wfi PSF option in the ensemble pipeline.
+
+Covers (a) PSF config parsing: the ``type: roman_wfi`` schema, defaults,
+gaussian backward compatibility, and loud rejection of unknown/malformed
+specs; (b) monochromatic ``galsim.roman.getPSF`` kernel construction:
+unit normalization, the pinned kernel stamp shape across the ensemble z
+range, and the wavelength-scaling physics sanity check; (c) obs
+construction with a roman PSF plus the explicit-kernel-size validation
+added to the kernel-render path.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import yaml
+
+from kl_pipe.ensemble.mocks import (
+    _band_effective_wavelength_nm,
+    _build_band_psf,
+    _build_grism_psf,
+    _get_roman_wfi_psf,
+    _grism_psf_kernel_size,
+    build_fit_inputs,
+)
+from kl_pipe.ensemble.scene import scene_truth_defaults
+from kl_pipe.ensemble.spec import EnsembleSpec, ObservingConfig, PSFSpec
+from kl_pipe.lines import LINE_LAMBDAS
+from kl_pipe.observation import build_grism_obs, build_image_obs
+from kl_pipe.parameters import ImagePars
+from kl_pipe.psf import precompute_psf_fft
+from kl_pipe.render import RenderConfig
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REGISTRY = REPO_ROOT / 'configs' / 'observing'
+DEV_SPEC = REPO_ROOT / 'configs' / 'ensembles' / 'sigma_eps_cosi_dev.yaml'
+
+# canonical geometry (matches the observing-config registry)
+PIXEL_SCALE = 0.11  # arcsec/pix
+
+# ensemble z range endpoints (specs draw z uniform on [1.0, 1.9])
+Z_LO = 0.55
+Z_HI = 1.9
+
+ROMAN_SPEC = PSFSpec(psf_type='roman_wfi', sca=10, pupil_bin=4)
+
+
+def _config_dict() -> dict:
+    return yaml.safe_load((REGISTRY / 'canonical_Q.yaml').read_text())
+
+
+def _write_config(tmp_path: Path, config_dict: dict) -> Path:
+    path = tmp_path / 'obs.yaml'
+    path.write_text(yaml.safe_dump(config_dict))
+    return path
+
+
+def _pinned_kernel_size(pixel_scale: float, z_max: float = Z_HI) -> int:
+    """Good image size at the largest ensemble wavelength, forced odd."""
+    psf = _build_grism_psf(ROMAN_SPEC, z_max)
+    size = int(psf.getGoodImageSize(pixel_scale))
+    if size % 2 == 0:
+        size += 1
+    return size
+
+
+# ==============================================================================
+# Config parsing
+# ==============================================================================
+
+
+class TestRomanPSFConfig:
+    def test_registry_roman_config_loads(self):
+        config = ObservingConfig.from_yaml(REGISTRY / 'canonical_P_roman.yaml')
+        assert config.bands == ('H158', 'F184')
+        assert config.grism_rolls_deg == (0.0, 45.0, 90.0, 135.0)
+        for band in config.bands:
+            assert config.band_psf[band].psf_type == 'roman_wfi'
+            assert config.band_psf[band].sca == 10
+            assert config.band_psf[band].pupil_bin == 4
+        assert config.grism_psf.psf_type == 'roman_wfi'
+
+    def test_roman_defaults_applied(self, tmp_path):
+        d = _config_dict()
+        d['psf']['broadband'] = {'type': 'roman_wfi'}
+        d['psf']['grism'] = {'type': 'roman_wfi'}
+        config = ObservingConfig.from_yaml(_write_config(tmp_path, d))
+        assert config.band_psf['F087'].sca == 10
+        assert config.band_psf['F087'].pupil_bin == 4
+        assert config.grism_psf.sca == 10
+        assert config.grism_psf.pupil_bin == 4
+
+    def test_explicit_sca_pupil_bin(self, tmp_path):
+        d = _config_dict()
+        d['psf']['grism'] = {'type': 'roman_wfi', 'sca': 4, 'pupil_bin': 8}
+        config = ObservingConfig.from_yaml(_write_config(tmp_path, d))
+        assert config.grism_psf.sca == 4
+        assert config.grism_psf.pupil_bin == 8
+
+    def test_mixed_gaussian_broadband_roman_grism(self, tmp_path):
+        d = _config_dict()
+        d['psf']['grism'] = {'type': 'roman_wfi'}
+        config = ObservingConfig.from_yaml(_write_config(tmp_path, d))
+        assert config.band_psf['F087'].psf_type == 'gaussian'
+        assert config.band_psf_fwhm == {'F087': 0.18}
+        assert config.grism_psf.psf_type == 'roman_wfi'
+
+    def test_gaussian_configs_unchanged(self):
+        config = ObservingConfig.from_yaml(REGISTRY / 'canonical_P.yaml')
+        assert config.band_psf_fwhm == {'F087': 0.18, 'F158': 0.18}
+        assert config.grism_psf_fwhm == 0.18
+
+    def test_fwhm_properties_raise_for_roman(self):
+        config = ObservingConfig.from_yaml(REGISTRY / 'canonical_P_roman.yaml')
+        with pytest.raises(ValueError, match='gaussian PSFs only'):
+            config.band_psf_fwhm
+        with pytest.raises(ValueError, match='gaussian PSFs only'):
+            config.grism_psf_fwhm
+
+    def test_unknown_type_raises(self, tmp_path):
+        for channel in ('broadband', 'grism'):
+            d = _config_dict()
+            d['psf'][channel] = {'type': 'imcom'}
+            with pytest.raises(NotImplementedError, match='not supported'):
+                ObservingConfig.from_yaml(_write_config(tmp_path, d))
+
+    def test_roman_with_fwhm_key_raises(self, tmp_path):
+        d = _config_dict()
+        d['psf']['grism'] = {'type': 'roman_wfi', 'fwhm_arcsec': 0.18}
+        with pytest.raises(ValueError, match='unknown keys'):
+            ObservingConfig.from_yaml(_write_config(tmp_path, d))
+
+    def test_bad_sca_raises(self, tmp_path):
+        for sca in (0, 19):
+            d = _config_dict()
+            d['psf']['grism'] = {'type': 'roman_wfi', 'sca': sca}
+            with pytest.raises(ValueError, match='sca'):
+                ObservingConfig.from_yaml(_write_config(tmp_path, d))
+
+    def test_bad_pupil_bin_raises(self, tmp_path):
+        d = _config_dict()
+        d['psf']['grism'] = {'type': 'roman_wfi', 'pupil_bin': 0}
+        with pytest.raises(ValueError, match='pupil_bin'):
+            ObservingConfig.from_yaml(_write_config(tmp_path, d))
+
+    def test_psfspec_cross_field_validation(self):
+        with pytest.raises(ValueError, match='roman_wfi-only'):
+            PSFSpec(psf_type='gaussian', fwhm_arcsec=0.18, sca=10)
+        with pytest.raises(ValueError, match='gaussian-only'):
+            PSFSpec(psf_type='roman_wfi', fwhm_arcsec=0.18, sca=10, pupil_bin=4)
+        with pytest.raises(ValueError, match='fwhm_arcsec'):
+            PSFSpec(psf_type='gaussian')
+        with pytest.raises(NotImplementedError, match='not supported'):
+            PSFSpec(psf_type='airy')
+
+
+# ==============================================================================
+# Kernel construction (monochromatic getPSF)
+# ==============================================================================
+
+
+class TestRomanKernel:
+    def test_grism_psf_wavelength_and_cache(self):
+        lam = round(LINE_LAMBDAS['Halpha'] * (1.0 + Z_HI), 1)
+        psf_a = _get_roman_wfi_psf(10, 4, lam, bandpass=None)
+        # wavelengths rounding to the same 0.1 nm key hit the cache
+        psf_b = _get_roman_wfi_psf(10, 4, lam + 0.04, bandpass=None)
+        assert psf_a is psf_b
+        # repeated builds at the same z reuse the cached object
+        assert _build_grism_psf(ROMAN_SPEC, Z_HI) is _build_grism_psf(ROMAN_SPEC, Z_HI)
+
+    def test_band_effective_wavelengths(self):
+        # galsim.roman effective wavelengths are in nm; H158/F184 pivots
+        # are ~1.58/1.84 um, a loose bracket guards a silent unit change
+        lam_h158 = _band_effective_wavelength_nm('H158')
+        lam_f184 = _band_effective_wavelength_nm('F184')
+        assert 1500.0 < lam_h158 < 1650.0
+        assert 1750.0 < lam_f184 < 1900.0
+
+    def test_non_roman_band_raises(self):
+        # flagship band names (F087/F158) are not Roman WFI bandpasses
+        with pytest.raises(ValueError, match='not a Roman WFI bandpass'):
+            _build_band_psf(ROMAN_SPEC, 'F087')
+
+    def test_kernel_unit_normalized_and_finite(self):
+        psf = _build_grism_psf(ROMAN_SPEC, 1.2)
+        pin = _pinned_kernel_size(PIXEL_SCALE)
+        psf_data = precompute_psf_fft(
+            psf, image_shape=(32, 32), pixel_scale=PIXEL_SCALE, kernel_size=pin
+        )
+        kernel_fft = np.asarray(psf_data.kernel_fft)
+        assert np.all(np.isfinite(kernel_fft))
+        # unit-sum kernel: DC component of its FFT is exactly the sum
+        assert kernel_fft[0, 0].real == pytest.approx(1.0, abs=1e-12)
+        assert kernel_fft[0, 0].imag == pytest.approx(0.0, abs=1e-12)
+
+    def test_pinned_shape_constant_across_z(self):
+        pin = _pinned_kernel_size(PIXEL_SCALE)
+        shapes = {}
+        for z in (Z_LO, Z_HI):
+            psf = _build_grism_psf(ROMAN_SPEC, z)
+            psf_data = precompute_psf_fft(
+                psf, image_shape=(32, 32), pixel_scale=PIXEL_SCALE, kernel_size=pin
+            )
+            shapes[z] = (psf_data.padded_shape, psf_data.kernel_fft.shape)
+        assert shapes[Z_LO] == shapes[Z_HI]
+
+    def test_higher_z_kernel_broader(self):
+        # physics sanity: diffraction-limited size scales ~lambda/D, so the
+        # z=1.9 kernel (1903 nm) must be measurably broader than z=0.55
+        # (1017 nm); expected half-light-radius ratio ~1.87, assert > 1.3
+        # to allow pupil-detail deviations while staying loudly physical.
+        # Measured at the ensemble's fine pixel scale (oversample 3) -- the
+        # coarse 0.11 arcsec pixels quantize the HLR below one pixel.
+        fine_ps = PIXEL_SCALE / 3
+        pin = _pinned_kernel_size(fine_ps)
+
+        def half_light_radius(z: float) -> float:
+            psf = _build_grism_psf(ROMAN_SPEC, z)
+            image = psf.drawImage(nx=pin, ny=pin, scale=fine_ps).array
+            image = image / image.sum()
+            center = (pin - 1) / 2.0
+            yy, xx = np.mgrid[0:pin, 0:pin]
+            radius = np.hypot(xx - center, yy - center).ravel()
+            order = np.argsort(radius)
+            cumulative = np.cumsum(image.ravel()[order])
+            return float(radius[order][np.searchsorted(cumulative, 0.5)])
+
+        hlr_lo = half_light_radius(Z_LO)
+        hlr_hi = half_light_radius(Z_HI)
+        assert hlr_hi > 1.3 * hlr_lo
+
+    def test_too_small_kernel_size_raises(self):
+        psf = _build_grism_psf(ROMAN_SPEC, Z_HI)
+        with pytest.raises(ValueError, match='truncate'):
+            precompute_psf_fft(
+                psf, image_shape=(32, 32), pixel_scale=PIXEL_SCALE, kernel_size=31
+            )
+
+    def test_even_kernel_size_raises(self):
+        psf = _build_grism_psf(ROMAN_SPEC, Z_HI)
+        pin = _pinned_kernel_size(PIXEL_SCALE) + 1  # even
+        with pytest.raises(ValueError, match='odd'):
+            precompute_psf_fft(
+                psf, image_shape=(32, 32), pixel_scale=PIXEL_SCALE, kernel_size=pin
+            )
+
+    def test_pinning_helper(self, tmp_path):
+        spec = EnsembleSpec.from_yaml(DEV_SPEC)
+        d = _config_dict()
+        d['psf']['grism'] = {'type': 'roman_wfi'}
+        config = ObservingConfig.from_yaml(_write_config(tmp_path, d))
+        size = _grism_psf_kernel_size(config, spec)
+        fine_ps = config.pixel_scale_arcsec / config.oversample
+        # dev spec draws z uniform on [1.0, 1.9]: pin at z=1.9
+        assert size == _pinned_kernel_size(fine_ps, z_max=1.9)
+        assert size % 2 == 1
+        # gaussian grism psf needs no pinning
+        gaussian_config = ObservingConfig.from_yaml(REGISTRY / 'canonical_Q.yaml')
+        assert _grism_psf_kernel_size(gaussian_config, spec) is None
+
+
+# ==============================================================================
+# Obs construction
+# ==============================================================================
+
+
+class TestRomanObs:
+    def test_image_obs_kernel_size_guards(self):
+        image_pars = ImagePars(shape=(32, 32), pixel_scale=PIXEL_SCALE, indexing='ij')
+        psf = _build_grism_psf(ROMAN_SPEC, 1.2)
+        with pytest.raises(ValueError, match='without a psf'):
+            build_image_obs(
+                image_pars,
+                render_config=RenderConfig(oversample=1),
+                psf_kernel_size=101,
+            )
+        with pytest.raises(ValueError, match='explicit render_config'):
+            build_image_obs(image_pars, psf=psf, psf_kernel_size=101)
+
+    def test_image_obs_with_roman_psf(self):
+        image_pars = ImagePars(shape=(32, 32), pixel_scale=PIXEL_SCALE, indexing='ij')
+        psf = _build_band_psf(ROMAN_SPEC, 'H158')
+        obs = build_image_obs(
+            image_pars, psf=psf, render_config=RenderConfig(oversample=1)
+        )
+        assert obs.psf_data is not None
+        assert np.all(np.isfinite(np.asarray(obs.psf_data.kernel_fft)))
+
+    def test_grism_obs_pinned_shapes_match_across_z(self, tmp_path):
+        from kl_pipe.dispersion import build_grism_pars_for_line
+
+        pin = _pinned_kernel_size(PIXEL_SCALE)
+        shapes = {}
+        for z in (Z_LO, Z_HI):
+            grism_pars = build_grism_pars_for_line(
+                LINE_LAMBDAS['Halpha'],
+                redshift=z,
+                image_pars=ImagePars(
+                    shape=(32, 32), pixel_scale=PIXEL_SCALE, indexing='ij'
+                ),
+                dispersion=1.1,
+            )
+            obs = build_grism_obs(
+                grism_pars,
+                z=z,
+                psf=_build_grism_psf(ROMAN_SPEC, z),
+                render_config=RenderConfig(oversample=1),
+                psf_kernel_size=pin,
+            )
+            shapes[z] = (obs.psf_data.padded_shape, obs.psf_data.kernel_fft.shape)
+        assert shapes[Z_LO] == shapes[Z_HI]
+
+
+@pytest.mark.slow
+def test_build_fit_inputs_roman_smoke(tmp_path):
+    """End-to-end mock construction with roman_wfi PSFs on both channels:
+    one H158 band + one grism roll, oversample 1 to keep the kernel grids
+    small. Asserts valid PSFData on every obs, finite noisy data, and a
+    finite truth render through the fit's own obs."""
+    spec = EnsembleSpec.from_yaml(DEV_SPEC)
+    d = _config_dict()
+    d['id'] = 'roman_smoke'
+    d['bands'] = ['H158']
+    d['psf'] = {
+        'broadband': {'type': 'roman_wfi'},
+        'grism': {'type': 'roman_wfi'},
+    }
+    d['render'] = {'oversample': 1}
+    config = ObservingConfig.from_yaml(_write_config(tmp_path, d))
+
+    truth = scene_truth_defaults(config, spec.fixed)
+    truth.update(
+        {
+            'cosi': 0.5,
+            'theta_int': 0.6,
+            'g1': 0.02,
+            'g2': -0.01,
+            'vel.vcirc': 200.0,
+            'z': 1.2,
+        }
+    )
+    inputs = build_fit_inputs(
+        truth, 11, spec, config, broadband_snr=100.0, line_snr=100.0
+    )
+
+    assert set(inputs.image_obs) == {'H158'}
+    assert set(inputs.grism_obs) == {'roll0'}
+    for obs in list(inputs.image_obs.values()) + list(inputs.grism_obs.values()):
+        assert obs.psf_data is not None
+        assert np.all(np.isfinite(np.asarray(obs.data)))
+        assert float(np.asarray(obs.variance)) > 0
+
+    band_render = np.asarray(
+        inputs.source.render_broadband(truth, inputs.image_obs['H158'], 'H158')
+    )
+    grism_render = np.asarray(
+        inputs.source.render_grism(truth, inputs.grism_obs['roll0'])
+    )
+    assert np.all(np.isfinite(band_render))
+    assert np.all(np.isfinite(grism_render))
+    assert band_render.sum() > 0
+    assert grism_render.sum() > 0

--- a/tests/test_roman_psf.py
+++ b/tests/test_roman_psf.py
@@ -443,6 +443,178 @@ class TestRomanObs:
         assert maxk <= float(psf.maxk) + 1e-9
 
 
+def _folding_scan_inputs(tmp_path, ft, seed=11):
+    """FitInputs for the folding-threshold scan scene (single F158 band +
+    single roll, roman PSFs, oversample 3, z=1.2, line SNR 100)."""
+    d = _config_dict()
+    d['id'] = f'roman_folding_{ft}'
+    d['bands'] = ['F158']
+    d['psf'] = {
+        'broadband': {'type': 'roman_wfi'},
+        'grism': {'type': 'roman_wfi'},
+    }
+    if ft is not None:
+        d['psf']['broadband']['folding_threshold'] = ft
+        d['psf']['grism']['folding_threshold'] = ft
+    d['render'] = {'oversample': 3}
+    config = ObservingConfig.from_yaml(_write_config(tmp_path, d))
+    spec = EnsembleSpec.from_yaml(DEV_SPEC)
+    truth = scene_truth_defaults(config, spec.fixed)
+    truth.update(
+        {
+            'cosi': 0.5,
+            'theta_int': 0.6,
+            'g1': 0.02,
+            'g2': -0.01,
+            'vel.vcirc': 200.0,
+            'z': 1.2,
+        }
+    )
+    return (
+        build_fit_inputs(
+            truth, seed, spec, config, broadband_snr=100.0, line_snr=100.0
+        ),
+        truth,
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.diagnostic_plots
+def test_folding_threshold_diagnostic_plot(tmp_path):
+    """Diagnostic figure for the roman_wfi folding_threshold knob: kernel
+    stamp / padded-FFT size, log-posterior+gradient eval time, and render
+    distortion vs the default-threshold reference, plus per-threshold grism
+    residual maps in noise units (line SNR 100). Values are measured fresh
+    each run; the figure and CSV land in tests/out/roman_psf_folding/."""
+    import time
+
+    import matplotlib
+
+    matplotlib.use('Agg')
+    import matplotlib.pyplot as plt
+
+    import jax
+
+    from kl_pipe.sampling import InferenceTask
+
+    out_dir = REPO_ROOT / 'tests' / 'out' / 'roman_psf_folding'
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    thresholds = [None, 0.01, 0.02, 0.05]
+    fine_ps = PIXEL_SCALE / 3
+    rows = []
+    renders = {}
+    for ft in thresholds:
+        inputs, truth = _folding_scan_inputs(tmp_path, ft)
+        roll0 = inputs.grism_obs['roll0']
+        renders[ft] = np.asarray(inputs.source.render_grism(truth, roll0))
+
+        spec_ft = (
+            ROMAN_SPEC
+            if ft is None
+            else PSFSpec(
+                psf_type='roman_wfi', sca=10, pupil_bin=4, folding_threshold=ft
+            )
+        )
+        stamp = int(_build_grism_psf(spec_ft, Z_HI).getGoodImageSize(fine_ps))
+
+        task = InferenceTask.from_obs(
+            inputs.source,
+            inputs.priors,
+            image_obs=inputs.image_obs,
+            grism_obs=inputs.grism_obs,
+        )
+        fn = task.get_log_posterior_and_grad_fn()
+        theta0 = np.asarray(task.sample_prior(jax.random.PRNGKey(0), 1))[0]
+        val, grad = fn(theta0)  # compile
+        float(val), np.asarray(grad)
+        times = []
+        for i in range(10):
+            t0 = time.perf_counter()
+            v, g = fn(theta0 * (1.0 + 1e-4 * (i + 1)))
+            float(v), np.asarray(g)
+            times.append(time.perf_counter() - t0)
+
+        rows.append(
+            {
+                'folding_threshold': 5e-3 if ft is None else ft,
+                'kernel_stamp_fine_px': stamp,
+                'padded_fft_side': int(roll0.psf_data.padded_shape[0]),
+                'eval_median_ms': 1e3 * float(np.median(times)),
+                'sigma_pix': float(np.sqrt(float(np.asarray(roll0.variance)))),
+            }
+        )
+
+    ref = renders[None]
+    sigma = rows[0]['sigma_pix']
+    for row, ft in zip(rows, thresholds):
+        diff = renders[ft] - ref
+        row['maxabs_over_peak'] = float(np.max(np.abs(diff)) / np.max(ref))
+        row['stamp_chi_snr100'] = float(np.sqrt(np.sum(diff**2)) / sigma)
+
+    with open(out_dir / 'folding_scan.csv', 'w') as f:
+        keys = list(rows[0])
+        f.write(','.join(keys) + '\n')
+        for row in rows:
+            f.write(','.join(str(row[k]) for k in keys) + '\n')
+
+    fts = [r['folding_threshold'] for r in rows]
+    fig = plt.figure(figsize=(15, 8))
+    gs = fig.add_gridspec(2, 3, height_ratios=[1, 1])
+
+    ax = fig.add_subplot(gs[0, 0])
+    ax.plot(fts, [r['kernel_stamp_fine_px'] for r in rows], 'o-', label='kernel stamp')
+    ax.plot(fts, [r['padded_fft_side'] for r in rows], 's--', label='padded FFT side')
+    ax.set_xscale('log')
+    ax.set_xlabel('folding_threshold')
+    ax.set_ylabel('size [fine px]')
+    ax.legend()
+    ax.set_title('grism kernel / FFT size (pin z=1.9)')
+
+    ax = fig.add_subplot(gs[0, 1])
+    ax.plot(fts, [r['eval_median_ms'] for r in rows], 'o-')
+    ax.set_xscale('log')
+    ax.set_xlabel('folding_threshold')
+    ax.set_ylabel('logpost+grad eval [ms]')
+    ax.set_title('eval time (this host, this run)')
+
+    ax = fig.add_subplot(gs[0, 2])
+    ax.plot(
+        fts[1:], [r['maxabs_over_peak'] for r in rows[1:]], 'o-', label='max|d|/peak'
+    )
+    ax.plot(
+        fts[1:],
+        [r['stamp_chi_snr100'] for r in rows[1:]],
+        's--',
+        label='whole-stamp chi @ line SNR 100',
+    )
+    ax.axhline(1.0, color='k', lw=0.8, ls=':', label='chi = 1')
+    ax.set_xscale('log')
+    ax.set_yscale('log')
+    ax.set_xlabel('folding_threshold')
+    ax.set_title('render distortion vs default kernel')
+    ax.legend()
+
+    for i, ft in enumerate(thresholds[1:]):
+        ax = fig.add_subplot(gs[1, i])
+        resid = (renders[ft] - ref) / sigma
+        vmax = max(1e-12, float(np.max(np.abs(resid))))
+        im = ax.imshow(resid, cmap='RdBu_r', vmin=-vmax, vmax=vmax, origin='lower')
+        fig.colorbar(im, ax=ax, shrink=0.8)
+        ax.set_title(f'(render - ref) / sigma, ft={ft}')
+
+    fig.suptitle(
+        'roman_wfi PSF folding_threshold: cost vs fidelity '
+        '(1-band + 1-roll scan scene, z=1.2, kernel pinned at z=1.9)'
+    )
+    fig.tight_layout()
+    fig.savefig(out_dir / 'folding_threshold_diagnostics.png', dpi=130)
+    plt.close(fig)
+
+    assert (out_dir / 'folding_threshold_diagnostics.png').exists()
+    assert (out_dir / 'folding_scan.csv').exists()
+
+
 @pytest.mark.slow
 def test_folding_threshold_render_fidelity(tmp_path):
     """Render distortion from a loosened kernel folding threshold, against
@@ -454,33 +626,7 @@ def test_folding_threshold_render_fidelity(tmp_path):
     independent of the drawn stamp), pinned here by exact equality."""
 
     def _clean_renders(ft):
-        d = _config_dict()
-        d['id'] = f'roman_fidelity_{ft}'
-        d['bands'] = ['F158']
-        d['psf'] = {
-            'broadband': {'type': 'roman_wfi'},
-            'grism': {'type': 'roman_wfi'},
-        }
-        if ft is not None:
-            d['psf']['broadband']['folding_threshold'] = ft
-            d['psf']['grism']['folding_threshold'] = ft
-        d['render'] = {'oversample': 3}
-        config = ObservingConfig.from_yaml(_write_config(tmp_path, d))
-        spec = EnsembleSpec.from_yaml(DEV_SPEC)
-        truth = scene_truth_defaults(config, spec.fixed)
-        truth.update(
-            {
-                'cosi': 0.5,
-                'theta_int': 0.6,
-                'g1': 0.02,
-                'g2': -0.01,
-                'vel.vcirc': 200.0,
-                'z': 1.2,
-            }
-        )
-        inputs = build_fit_inputs(
-            truth, 11, spec, config, broadband_snr=100.0, line_snr=100.0
-        )
+        inputs, truth = _folding_scan_inputs(tmp_path, ft)
         grism = np.asarray(inputs.source.render_grism(truth, inputs.grism_obs['roll0']))
         band = np.asarray(
             inputs.source.render_broadband(truth, inputs.image_obs['F158'], 'F158')

--- a/tests/test_roman_psf.py
+++ b/tests/test_roman_psf.py
@@ -25,7 +25,12 @@ from kl_pipe.ensemble.mocks import (
     build_fit_inputs,
 )
 from kl_pipe.ensemble.scene import scene_truth_defaults
-from kl_pipe.ensemble.spec import EnsembleSpec, ObservingConfig, PSFSpec
+from kl_pipe.ensemble.spec import (
+    EnsembleSpec,
+    FoldingThresholdTier,
+    ObservingConfig,
+    PSFSpec,
+)
 from kl_pipe.lines import LINE_LAMBDAS
 from kl_pipe.observation import build_grism_obs, build_image_obs
 from kl_pipe.parameters import ImagePars
@@ -78,15 +83,24 @@ class TestRomanPSFConfig:
         config = ObservingConfig.from_yaml(REGISTRY / 'canonical_P_roman.yaml')
         assert config.bands == ('F158', 'F184')
         assert config.grism_rolls_deg == (0.0, 45.0, 90.0, 135.0)
+        # 2026-07-19 ruling: fit kernels follow the z-tiered schedule
+        # (ft=0.01 for z<=1.2, tighter 5e-3 above == the mock default, so
+        # mock == fit at the tight tier); scalar folding_threshold retired
+        # from this config. Pin the FULL schedule; mock kernels at default.
+        ruling_tiers = (
+            FoldingThresholdTier(z_max=1.2, ft=0.01),
+            FoldingThresholdTier(z_max=None, ft=5.0e-3),
+        )
         for band in config.bands:
             assert config.band_psf[band].psf_type == 'roman_wfi'
             assert config.band_psf[band].sca == 10
             assert config.band_psf[band].pupil_bin == 4
-            # fit kernels loosened to 0.01 (gated); mock kernels at default
-            assert config.band_psf[band].folding_threshold == 0.01
+            assert config.band_psf[band].folding_threshold is None
+            assert config.band_psf[band].folding_threshold_tiers == ruling_tiers
             assert config.band_psf[band].mock_folding_threshold is None
         assert config.grism_psf.psf_type == 'roman_wfi'
-        assert config.grism_psf.folding_threshold == 0.01
+        assert config.grism_psf.folding_threshold is None
+        assert config.grism_psf.folding_threshold_tiers == ruling_tiers
         assert config.grism_psf.mock_folding_threshold is None
 
     def test_roman_defaults_applied(self, tmp_path):


### PR DESCRIPTION
## Summary

Wires the realistic Roman WFI PSF (`galsim.roman.getPSF`) into the ensemble production path as a config-boundary change; the render chain was already GSObject-agnostic. Gaussian configs are fully backward compatible.

This PR was done on a separate worktree from `se/speedups` to implement this infrastructure in parallel with the ensemble/GPU work. It merges into `se/speedups`, not `main`; no outside review needed.

- New PSFSpec config type `roman_wfi` (per-channel; `sca` default 10, `pupil_bin` default 4, optional `folding_threshold`); mixed gaussian/roman configs allowed; unknown types still raise.
- Configs use official Roman filter names (F158, F184); galsim's legacy WFIRST keys (H158, Z087, ...) are mapped at the galsim boundary and still accepted.
- Broadband kernels rendered monochromatic at the band effective wavelength (F158 1579 nm, F184 1842 nm; galsim 2.8.4, getPSF takes nm).
- Grism kernel rendered at the observed Halpha wavelength 656.28(1+z) nm per fit, with the kernel array shape pinned at the spec's z-draw upper bound so shapes are constant across the ensemble (persistent-compile-cache friendly). Pinning = zero-padding each fit's own correct kernel; never a worst-case PSF.
- `kernel_size` override in psf.py/observation.py: odd, >= GalSim good size, raises rather than truncate; preserved through `with_render_config` (obs field).
- Effective-maxk scans cap the PSF factor at `psf.maxk`: the interpolated-pupil PSF's kValue sidelobes exceed the 1e-3 threshold beyond the physical aperture cutoff, which inflated the priors-implied oversample to 7 and made `InferenceTask.from_obs` raise on the production worker path (found by audit; regression-tested).
- Process-level getPSF cache keyed (sca, pupil_bin, wavelength@0.1nm, bandpass, folding_threshold), FIFO-capped at 16.

## Measured cost + the folding_threshold knob

macbook CPU, canonical_P_roman vs canonical_P (gaussian), oversample 3, z=1.2, kernel pinned at z=1.9, logpost+grad eval median:

| config | grism padded FFT | eval | vs gaussian |
|---|---|---|---|
| gaussian canonical_P | 125^2 | 37.5 ms | 1.0x |
| roman, default kernels | 1089^2 | 141.6 ms | 3.8x |
| roman, folding_threshold 0.01 | 600^2 | 51.0 ms | 1.4x |
| roman, folding_threshold 0.02 | 350^2 | 35.0 ms | 0.9x |

Noiseless-render distortion vs default kernels at line SNR 100 (whole-stamp chi): 0.045 at ft=0.01, 0.51 at ft=0.02; broadband path unaffected (k-space analytic kernel FT, pinned by exact-equality test). Compile time unchanged. The knob is config-driven and NOT enabled in `canonical_P_roman.yaml`; production choice pending. Fidelity gate test bounds = 10x measured (provenance in test docstring).

## Deliberately out of scope

Flagship test migration to Roman PSF (frozen refs move; follow-up after this PR lands, with user consultation), chromatic/per-slice PSFs (issue #51), SCA-position dependence, ImCom coadd PSFs. Note: grism kernel-size pinning currently requires a uniform z draw; the planned LF-based n(z) sampler will hit a loud NotImplementedError there (extension scheduled with the population-sampler work).

## Review focus

**API:**
- `kl_pipe/ensemble/spec.py` -- PSFSpec dataclass + YAML schema (incl. folding_threshold)
- `kl_pipe/psf.py`, `kl_pipe/observation.py` -- kernel_size pinning semantics (Critical: refuses to truncate; requires explicit render_config when pinned)
- `kl_pipe/render.py` -- effective-maxk PSF band-limit cap (Critical: grid sizing)

**Internals:**
- `kl_pipe/ensemble/mocks.py` -- PSF builder dispatch, band-name map, getPSF cache, z-dependent grism kernel, pin-size helper

**Tests:**
- `tests/test_roman_psf.py` (37: parsing, kernel physics, shape pinning, sidelobe-cap regression, from_obs production path, folding fidelity gate)
- `tests/test_ensemble.py`, `tests/test_render_config.py` (accessor updates; _DeadPSF fake gains maxk)
- test_flagship and all frozen references untouched

Verified at 4a7e68a: test_roman_psf 34 (31 fast + 3 slow) passed; test_ensemble + test_render_config passed (107 fast total); earlier full adjacent sweep at 91f104f: 532 passed / 0 failed. make check-format clean (pre-commit black).

---

## Addendum (through e4b522c): rigor tests, z-tiered folding_threshold, rfft2 + minimal-padding swap

Five commits added after the original review round. All additive except one test-content pin refresh (flagged below).

**Rigor tests (123bad2).** Kernel-convention checks with the real (asymmetric) roman kernel: k-space fused path vs galsim native 7.0e-4 max|diff|/peak; a deliberately transposed kernel reads 8.0e-3 and the 2e-3 bound sits between, so a parity/orientation bug cannot pass. Real-space delta-patch identity 7.1e-8; kernel DC == 1; coarse pixel applied exactly once post-dispersion. maxk cap re-verified: psf.maxk = 0.992x the analytic aperture cutoff at z=0.55/1.2/1.9.

**z-tiered fit folding_threshold (25b6b00, d6940b9).** The z=1.2 dual-fidelity acceptance of ft=0.01 does not extend to high z: mock-vs-fit MAP bias grows with kernel size (cosi -0.093 sigma, g1 -0.037, continuum -0.066 at z=1.9). Fix: `PSFSpec.folding_threshold_tiers` (mutually exclusive with the scalar; loud validation; mock >= tightest tier enforced), and canonical_P_roman.yaml now runs ft=0.01 for z<=1.2, ft=5e-3 above. At the tight tier the fit kernel is bit-identical to the mock kernel (max|diff| = 0), so the mismatch is zero by construction. Cost at z=1.9 (interleaved A/B; ratios robust, absolutes contention-contaminated):

| psf.py | ft=0.01 | ft=5e-3 | tight/loose |
|---|---|---|---|
| pre-swap | 48.4 ms (600^2 grism FFT) | 134.0 ms (1089^2) | 2.77x |
| with the swap below | 37.0 ms (350^2) | 57.7 ms (594^2) | 1.56x |

Ensemble-mean multiplier at f(z>1.2) ~= 0.49 (population-proto selected n(z)): 1.87x pre-swap, 1.27x with the swap.

**rfft2 + minimal-exact padding (5c6f90c).** Single production path in psf.py, no config knob. FFT convolution is circular mod the padded size P; with kernel half-width H = K//2, wraparound can reach a retained pixel only if P < N + H, so P >= N + H is exact on the retained N x N crop -- the grid shrinks from N+K-1 to N+K//2 (roman wings make K >> N, hence the win). Kernel support is finite by construction (folding_threshold-sized drawImage stamp). Old path kept verbatim in tests as `_reference_full_pad_fft2_convolve`; direct old-vs-new gate over {symmetric, asymmetric} kernels x 4 grid parities: worst-case rel delta 5.6e-16 value, 6.1e-16 grad. Bound 1e-14 = float64-identity floor, not a physics tolerance. Diagnostic panel regenerates to tests/out/psf_rfft2_swap/.

**Existing-test change (e4b522c, the only one).** test_registry_roman_config_loads pinned the yaml's old scalar ft=0.01; refreshed to pin the full tier schedule + scalar None + mock unset -- strictly more constrained than before. No tolerance changed anywhere.

**Validation at e4b522c** (local; via python -m pytest): targeted psf/roman/ensemble/galsim/cube/grism suites 214 passed; fast tier 1116 passed / 2 skipped; flagship dev joint Nsigma 0.086, production 0.845 (gates < 3). Both flagship variants build PSFSpec inline, so they exercise the swap but not the yaml tiers -- tier coverage is unit-level (TestFoldingThresholdTiers, 12 tests) plus the registry pin; an e2e yaml-tier test is a follow-up.

**Review focus (additions):**

- (Critical) `kl_pipe/psf.py` -- the padding argument above is the correctness crux
- `kl_pipe/ensemble/spec.py` -- FoldingThresholdTier schedule + validation
- `configs/observing/canonical_P_roman.yaml` -- tier flip
- `kl_pipe/ensemble/mocks.py` -- scene z threaded into fit-kernel resolution
- tests: test_psf.py rfft2 gate (additive), TestFoldingThresholdTiers, TestRomanKernelConventions
